### PR TITLE
Use aspect ratio saved in Product to avoid layout shifting for Shrine

### DIFF
--- a/lib/studies/shrine/supplemental/balanced_layout.dart
+++ b/lib/studies/shrine/supplemental/balanced_layout.dart
@@ -226,7 +226,6 @@ List<List<Product>> balancedLayout({
   );
 
   // Check if this layout is cached.
-
   if (LayoutCache.of(context).containsKey(encodedParameters)) {
     return _generateLayout(
       products: products,
@@ -234,45 +233,10 @@ List<List<Product>> balancedLayout({
     );
   }
 
-  final List<Size> productSizes = [
-    for (var product in products)
-      _imageSize(
-        Image.asset(
-          product.assetName,
-          package: product.assetPackage,
-        ),
-      ),
-  ];
-
-  bool hasNullSize = false;
-  for (final productSize in productSizes) {
-    if (productSize == null) {
-      hasNullSize = true;
-      break;
-    }
-  }
-
-  if (hasNullSize) {
-    // If some image sizes are not read, return default layout.
-    // Default layout is not cached.
-
-    List<List<Product>> result =
-        List<List<Product>>.generate(columnCount, (columnIndex) => []);
-    for (var index = 0; index < products.length; ++index) {
-      result[index % columnCount].add(products[index]);
-    }
-
-    return result;
-  }
-
-  // All images have sizes. Use tailored layout.
-
   final List<double> productHeights = [
-    for (final productSize in productSizes)
-      productSize.height /
-              productSize.width *
-              (largeImageWidth + smallImageWidth) /
-              2 +
+    for (final product in products)
+      ((1 / product.assetAspectRatio) *
+              ((largeImageWidth + smallImageWidth) / 2)) +
           productCardAdditionalHeight,
   ];
 

--- a/lib/studies/shrine/supplemental/balanced_layout.dart
+++ b/lib/studies/shrine/supplemental/balanced_layout.dart
@@ -65,25 +65,6 @@ List<List<Product>> _generateLayout({
   ];
 }
 
-/// Returns the size of an [Image] widget.
-Size _imageSize(Image imageWidget) {
-  Size result;
-
-  imageWidget.image.resolve(ImageConfiguration()).addListener(
-    ImageStreamListener(
-      (info, synchronousCall) {
-        final finalImage = info.image;
-        result = Size(
-          finalImage.width.toDouble(),
-          finalImage.height.toDouble(),
-        );
-      },
-    ),
-  );
-
-  return result;
-}
-
 /// Given [columnObjects], list of the set of objects in each column,
 /// and [columnHeights], list of heights of each column,
 /// [_iterateUntilBalanced] moves and swaps objects between columns


### PR DESCRIPTION
This fixes the issue of layout shifting when an item is added to the cart.

The root cause of this was that the image loading was not working the first time, thus the calculation was not the same as the second time. Now that we have the aspect ratio saved for every product, we can just use that in the calculation so it will work the same every time.

Closes https://github.com/material-components/material-components-flutter-gallery/issues/554