### PR TITLE
Handle status bar theme change

### DIFF
--- a/lib/data/gallery_options.dart
+++ b/lib/data/gallery_options.dart
@@ -8,6 +8,7 @@ import 'dart:io' show Platform;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart' show timeDilation;
+import 'package:flutter/services.dart' show SystemChrome, SystemUiOverlayStyle;
 import 'package:gallery/constants.dart';
 
 enum CustomTextDirection {
@@ -234,9 +235,26 @@ class _ModelBindingState extends State<ModelBinding> {
     }
   }
 
+  void handleThemeChange(GalleryOptions newModel) {
+    switch (newModel.themeMode) {
+      case ThemeMode.system:
+        final brightness = WidgetsBinding.instance.window.platformBrightness;
+        SystemChrome.setSystemUIOverlayStyle(brightness == Brightness.dark
+            ? SystemUiOverlayStyle.light
+            : SystemUiOverlayStyle.dark);
+        break;
+      case ThemeMode.light:
+        SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle.dark);
+        break;
+      case ThemeMode.dark:
+        SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle.light);
+    }
+  }
+
   void updateModel(GalleryOptions newModel) {
     if (newModel != currentModel) {
       handleTimeDilation(newModel);
+      handleThemeChange(newModel);
       setState(() {
         currentModel = newModel;
       });


### PR DESCRIPTION
When the theme is changed, update the system UI overlay (in our case, we only care about the status bar) so that it is the expected darkness/brightness

Closes https://github.com/material-components/material-components-flutter-gallery/issues/444