### PR TITLE
Check group count of matched names in Route

### DIFF
--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -76,8 +76,10 @@ class RouteConfiguration {
       if (regExpPattern.hasMatch(settings.name)) {
         final match = regExpPattern.firstMatch(settings.name);
         Map<String, String> groupNameToMatch = {};
-        for (String groupName in match.groupNames) {
-          groupNameToMatch[groupName] = match.namedGroup(groupName);
+        if (match.groupCount > 0) {
+          for (String groupName in match.groupNames) {
+            groupNameToMatch[groupName] = match.namedGroup(groupName);
+          }
         }
         return MaterialPageRoute<void>(
           builder: (context) => path.builder(context, groupNameToMatch),


### PR DESCRIPTION
## Overview

When I run this project, I got a runtime error below. I added count check of matched names to fix this issue.

```
════════ Exception caught by widgets library ═══════════════════════════════════════════════════════
The following assertion was thrown building IconTheme(color: Color(0xff000000)):
A GlobalKey was used multiple times inside one widget's child list.

The offending GlobalKey was: [GlobalObjectKey<NavigatorState> _WidgetsAppState#23e2d]
The parent of the widgets with that key was: IconTheme
  color: Color(0xff000000)
The first child to get instantiated with that key became: Navigator-[GlobalObjectKey<NavigatorState> _WidgetsAppState#23e2d]
  dirty
  state: NavigatorState#41cda(lifecycle state: created)
The second child that was to be instantiated with that key was: IconTheme
  color: Color(0xff000000)
A GlobalKey can only be specified on one widget at a time in the widget tree.
The relevant error-causing widget was: 
  MaterialApp file:///Users/kitasuke/Development/gallery/lib/main.dart:37:18
When the exception was thrown, this was the stack: 
#0      Element._retakeInactiveElement.<anonymous closure> (package:flutter/src/widgets/framework.dart:3386:11)
#1      Element._retakeInactiveElement (package:flutter/src/widgets/framework.dart:3400:8)
#2      Element.inflateWidget (package:flutter/src/widgets/framework.dart:3428:32)
#3      Element.updateChild (package:flutter/src/widgets/framework.dart:3211:20)
#4      ComponentElement.performRebuild (package:flutter/src/widgets/framework.dart:4527:16)
...
════════════════════════════════════════════════════════════════════════════════════════════════════
```