### PR TITLE
Improve Focus support on Rally with new API that is available

### DIFF
--- a/lib/studies/rally/home.dart
+++ b/lib/studies/rally/home.dart
@@ -145,7 +145,10 @@ class _HomePageState extends State<HomePage>
               splashColor: Colors.transparent,
               highlightColor: Colors.transparent,
             ),
-            child: tabBarView,
+            child: FocusTraversalGroup(
+              policy: OrderedTraversalPolicy(),
+              child: tabBarView,
+            ),
           ),
         ),
       ),
@@ -218,16 +221,19 @@ class _RallyTabBar extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return TabBar(
-      // Setting isScrollable to true prevents the tabs from being
-      // wrapped in [Expanded] widgets, which allows for more
-      // flexible sizes and size animations among tabs.
-      isScrollable: true,
-      labelPadding: EdgeInsets.zero,
-      tabs: tabs,
-      controller: tabController,
-      // This hides the tab indicator.
-      indicatorColor: Colors.transparent,
+    return FocusTraversalOrder(
+      order: NumericFocusOrder(0),
+      child: TabBar(
+        // Setting isScrollable to true prevents the tabs from being
+        // wrapped in [Expanded] widgets, which allows for more
+        // flexible sizes and size animations among tabs.
+        isScrollable: true,
+        labelPadding: EdgeInsets.zero,
+        tabs: tabs,
+        controller: tabController,
+        // This hides the tab indicator.
+        indicatorColor: Colors.transparent,
+      ),
     );
   }
 }

--- a/lib/studies/rally/tabs/overview.dart
+++ b/lib/studies/rally/tabs/overview.dart
@@ -50,7 +50,9 @@ class _OverviewViewState extends State<OverviewView> {
                   width: 400,
                   child: Semantics(
                     sortKey: const OrdinalSortKey(2, name: sortKeyName),
-                    child: _AlertsView(alerts: alerts),
+                    child: FocusTraversalGroup(
+                      child: _AlertsView(alerts: alerts),
+                    ),
                   ),
                 ),
               ),
@@ -112,6 +114,7 @@ class _OverviewGrid extends StatelessWidget {
                   buildAccountDataListViews(accountDataList, context),
               buttonSemanticsLabel:
                   GalleryLocalizations.of(context).rallySeeAllAccounts,
+              order: 1,
             ),
           ),
           if (hasMultipleColumns) SizedBox(width: spacing),
@@ -123,6 +126,7 @@ class _OverviewGrid extends StatelessWidget {
               financialItemViews: buildBillDataListViews(billDataList, context),
               buttonSemanticsLabel:
                   GalleryLocalizations.of(context).rallySeeAllBills,
+              order: 2,
             ),
           ),
           _FinancialView(
@@ -132,6 +136,7 @@ class _OverviewGrid extends StatelessWidget {
                 buildBudgetDataListViews(budgetDataList, context),
             buttonSemanticsLabel:
                 GalleryLocalizations.of(context).rallySeeAllBudgets,
+            order: 3,
           ),
         ],
       );
@@ -226,53 +231,58 @@ class _FinancialView extends StatelessWidget {
     this.total,
     this.financialItemViews,
     this.buttonSemanticsLabel,
+    this.order,
   });
 
   final String title;
   final String buttonSemanticsLabel;
   final double total;
   final List<FinancialEntityCategoryView> financialItemViews;
+  final double order;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    return Container(
-      color: RallyColors.cardBackground,
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.stretch,
-        children: [
-          MergeSemantics(
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.stretch,
-              children: [
-                Padding(
-                  padding: const EdgeInsets.all(16),
-                  child: Text(title),
-                ),
-                Padding(
-                  padding: const EdgeInsets.only(left: 16, right: 16),
-                  child: Text(
-                    usdWithSignFormat(context).format(total),
-                    style: theme.textTheme.bodyText1.copyWith(
-                      fontSize: 44 / reducedTextScale(context),
-                      fontWeight: FontWeight.w600,
+    return FocusTraversalOrder(
+      order: NumericFocusOrder(order),
+      child: Container(
+        color: RallyColors.cardBackground,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            MergeSemantics(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Text(title),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.only(left: 16, right: 16),
+                    child: Text(
+                      usdWithSignFormat(context).format(total),
+                      style: theme.textTheme.bodyText1.copyWith(
+                        fontSize: 44 / reducedTextScale(context),
+                        fontWeight: FontWeight.w600,
+                      ),
                     ),
                   ),
-                ),
-              ],
+                ],
+              ),
             ),
-          ),
-          ...financialItemViews.sublist(
-              0, math.min(financialItemViews.length, 3)),
-          FlatButton(
-            child: Text(
-              GalleryLocalizations.of(context).rallySeeAll,
-              semanticsLabel: buttonSemanticsLabel,
+            ...financialItemViews.sublist(
+                0, math.min(financialItemViews.length, 3)),
+            FlatButton(
+              child: Text(
+                GalleryLocalizations.of(context).rallySeeAll,
+                semanticsLabel: buttonSemanticsLabel,
+              ),
+              textColor: Colors.white,
+              onPressed: () {},
             ),
-            textColor: Colors.white,
-            onPressed: () {},
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }

--- a/lib/studies/rally/tabs/settings.dart
+++ b/lib/studies/rally/tabs/settings.dart
@@ -17,19 +17,22 @@ class SettingsView extends StatefulWidget {
 class _SettingsViewState extends State<SettingsView> {
   @override
   Widget build(BuildContext context) {
-    return Container(
-      padding: EdgeInsets.only(top: isDisplayDesktop(context) ? 24 : 0),
-      child: ListView(
-        shrinkWrap: true,
-        children: [
-          for (String title in DummyDataService.getSettingsTitles(context)) ...[
-            _SettingsItem(title),
-            Divider(
-              color: RallyColors.dividerColor,
-              height: 1,
-            )
-          ]
-        ],
+    return FocusTraversalGroup(
+      child: Container(
+        padding: EdgeInsets.only(top: isDisplayDesktop(context) ? 24 : 0),
+        child: ListView(
+          shrinkWrap: true,
+          children: [
+            for (String title
+                in DummyDataService.getSettingsTitles(context)) ...[
+              _SettingsItem(title),
+              Divider(
+                color: RallyColors.dividerColor,
+                height: 1,
+              )
+            ]
+          ],
+        ),
       ),
     );
   }


### PR DESCRIPTION
We can now set the sort order for Focus, so this improves the Focus support within Rally.

Closes https://github.com/material-components/material-components-flutter-gallery/issues/491