### PR TITLE
Set minimum version of Flutter to current version on master channel

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -476,4 +476,4 @@ packages:
     version: "2.2.0"
 sdks:
   dart: ">=2.6.0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.4 <2.0.0"
+  flutter: ">=1.16.0 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,6 +5,7 @@ version: 2.3.0+020300
 
 environment:
   sdk: ">=2.3.0 <3.0.0"
+  flutter: ^1.16.0
 
 dependencies:
   flutter:


### PR DESCRIPTION
To avoid confusion, and make it clear that Flutter needs to be run on the master channel, set the minimum version to what is currently on master.

See comments for reasoning why: https://github.com/flutter/gallery/pull/17#pullrequestreview-380142687