### PR TITLE
Prevent dropdown list build at startup

### DIFF
--- a/lib/pages/settings_list_item.dart
+++ b/lib/pages/settings_list_item.dart
@@ -243,7 +243,7 @@ class _SettingsListItemState<T> extends State<SettingsListItem<T>>
           shrinkWrap: true,
           physics: const NeverScrollableScrollPhysics(),
           itemBuilder: (context, index) => optionWidgetsList[index],
-          itemCount: optionWidgetsList.length,
+          itemCount: widget.isExpanded ? optionWidgetsList.length : 0,
         ),
       ),
     );


### PR DESCRIPTION
The app is currently building (layout) all dropdowns and dropdown contents at startup. Layout of thousands of text items is expensive, especially for web.

Before:
![Screen Shot 2020-04-20 at 9 48 10 AM](https://user-images.githubusercontent.com/5061034/79777850-b8a5fc80-82ec-11ea-825b-0ceaec021a5e.png)

After:
![Screen Shot 2020-04-20 at 9 50 35 AM](https://user-images.githubusercontent.com/5061034/79777865-bd6ab080-82ec-11ea-8ee6-d3ece65d6e92.png)
