### PR TITLE
fix: title called on null error on Fuchsia

### DIFF
--- a/lib/pages/settings_list_item.dart
+++ b/lib/pages/settings_list_item.dart
@@ -169,7 +169,7 @@ class _SettingsListItemState<T> extends State<SettingsListItem<T>>
           subtitleHeight: _headerSubtitleHeight,
           chevronRotation: _headerChevronRotation,
           title: widget.title,
-          subtitle: widget.options[widget.selectedOption].title ?? '',
+          subtitle: widget.options[widget.selectedOption]?.title ?? '',
           onTap: () => widget.onTapSetting(),
         ),
         Padding(


### PR DESCRIPTION
this patch fixes the below bug on fuchsia

```
[00866.211] 47871:48563> flutter_gallery.cmx(flutter):  EXCEPTION CAUGHT BY WIDGETS LIBRARY 
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): The following NoSuchMethodError was thrown building AnimatedBuilder(animation:
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): AnimationController#51066( 0.000; paused), dirty, state: _AnimatedState#fe4c1):
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): The getter 'title' was called on null.
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): Receiver: null
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): Tried calling: title
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): 
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): Widget creation tracking is currently disabled. Enabling it enables improved error messages. It can
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): be enabled by passing `--track-widget-creation` to `flutter run` or `flutter test`.
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): 
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): When the exception was thrown, this was the stack:
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): #0      Object.noSuchMethod (dart:core-patch/object_patch.dart:53:5)
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): #1      _SettingsListItemState._buildHeaderWithChildren (package:flutter_gallery/pages/settings_list_item.dart:172:59)
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): #2      AnimatedBuilder.build (package:flutter/src/widgets/transitions.dart:1124:19)
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): #3      _AnimatedState.build (package:flutter/src/widgets/transitions.dart:177:48)
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): #4      StatefulElement.build (package:flutter/src/widgets/framework.dart:4623:28)
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): #5      ComponentElement.performRebuild (package:flutter/src/widgets/framework.dart:4506:15)
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): #6      StatefulElement.performRebuild (package:flutter/src/widgets/framework.dart:4679:11)
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): #7      Element.rebuild (package:flutter/src/widgets/framework.dart:4222:5)
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): #8      ComponentElement._firstBuild (package:flutter/src/widgets/framework.dart:4485:5)
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): #9      StatefulElement._firstBuild (package:flutter/src/widgets/framework.dart:4670:11)
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): #10     ComponentElement.mount (package:flutter/src/widgets/framework.dart:4480:5)
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): ...     Normal element mounting (20 frames)
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): #30     Element.inflateWidget (package:flutter/src/widgets/framework.dart:3450:14)
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): #31     MultiChildRenderObjectElement.mount (package:flutter/src/widgets/framework.dart:5951:32)
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): ...     Normal element mounting (42 frames)
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): #73     Element.inflateWidget (package:flutter/src/widgets/framework.dart:3450:14)
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): #74     Element.updateChild (package:flutter/src/widgets/framework.dart:3218:18)
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): #75     SliverMultiBoxAdaptorElement.updateChild (package:flutter/src/widgets/sliver.dart:1162:36)
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): #76     SliverMultiBoxAdaptorElement.createChild.<anonymous closure> (package:flutter/src/widgets/sliver.dart:1147:20)
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): #77     BuildOwner.buildScope (package:flutter/src/widgets/framework.dart:2607:19)
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): #78     SliverMultiBoxAdaptorElement.createChild (package:flutter/src/widgets/sliver.dart:1140:11)
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): #79     RenderSliverMultiBoxAdaptor._createOrObtainChild.<anonymous closure> (package:flutter/src/rendering/sliver_multi_box_adaptor.dart:354:23)
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): #80     RenderObject.invokeLayoutCallback.<anonymous closure> (package:flutter/src/rendering/object.dart:1866:58)
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): #81     PipelineOwner._enableMutationsToDirtySubtrees (package:flutter/src/rendering/object.dart:918:15)
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): #82     RenderObject.invokeLayoutCallback (package:flutter/src/rendering/object.dart:1866:13)
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): #83     RenderSliverMultiBoxAdaptor._createOrObtainChild (package:flutter/src/rendering/sliver_multi_box_adaptor.dart:343:5)
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): #84     RenderSliverMultiBoxAdaptor.insertAndLayoutChild (package:flutter/src/rendering/sliver_multi_box_adaptor.dart:489:5)
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): #85     RenderSliverList.performLayout.advance (package:flutter/src/rendering/sliver_list.dart:219:19)
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): #86     RenderSliverList.performLayout (package:flutter/src/rendering/sliver_list.dart:262:19)
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): #87     RenderObject.layout (package:flutter/src/rendering/object.dart:1767:7)
[00866.211] 47871:48563> flutter_gallery.cmx(flutter): #88     RenderSliverEdgeInsetsPadding.performLayout (package:flutter/src/rendering/sliver_padding.dart:135:11)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #89     RenderSliverPadding.performLayout (package:flutter/src/rendering/sliver_padding.dart:375:11)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #90     RenderObject.layout (package:flutter/src/rendering/object.dart:1767:7)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #91     RenderViewportBase.layoutChildSequence (package:flutter/src/rendering/viewport.dart:452:13)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #92     RenderViewport._attemptLayout (package:flutter/src/rendering/viewport.dart:1444:12)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #93     RenderViewport.performLayout (package:flutter/src/rendering/viewport.dart:1353:20)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #94     RenderObject.layout (package:flutter/src/rendering/object.dart:1767:7)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #95     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:111:13)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #96     RenderObject.layout (package:flutter/src/rendering/object.dart:1767:7)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #97     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:111:13)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #98     RenderObject.layout (package:flutter/src/rendering/object.dart:1767:7)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #99     RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:111:13)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #100    RenderObject.layout (package:flutter/src/rendering/object.dart:1767:7)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #101    RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:111:13)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #102    RenderObject.layout (package:flutter/src/rendering/object.dart:1767:7)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #103    RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:111:13)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #104    RenderObject.layout (package:flutter/src/rendering/object.dart:1767:7)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #105    RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:111:13)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #106    RenderObject.layout (package:flutter/src/rendering/object.dart:1767:7)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #107    RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:111:13)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #108    RenderObject.layout (package:flutter/src/rendering/object.dart:1767:7)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #109    RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:111:13)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #110    RenderObject.layout (package:flutter/src/rendering/object.dart:1767:7)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #111    RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:111:13)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #112    RenderObject.layout (package:flutter/src/rendering/object.dart:1767:7)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #113    RenderPadding.performLayout (package:flutter/src/rendering/shifted_box.dart:207:11)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #114    RenderObject.layout (package:flutter/src/rendering/object.dart:1767:7)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #115    RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:111:13)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #116    RenderObject.layout (package:flutter/src/rendering/object.dart:1767:7)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #117    RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:111:13)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #118    _RenderCustomClip.performLayout (package:flutter/src/rendering/proxy_box.dart:1248:11)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #119    RenderObject.layout (package:flutter/src/rendering/object.dart:1767:7)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #120    RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:111:13)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #121    RenderObject.layout (package:flutter/src/rendering/object.dart:1767:7)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #122    RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:111:13)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #123    RenderObject.layout (package:flutter/src/rendering/object.dart:1767:7)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #124    RenderStack.layoutPositionedChild (package:flutter/src/rendering/stack.dart:487:11)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #125    RenderStack.performLayout (package:flutter/src/rendering/stack.dart:583:30)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #126    RenderObject.layout (package:flutter/src/rendering/object.dart:1767:7)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #127    _RenderLayoutBuilder.performLayout (package:flutter/src/widgets/layout_builder.dart:246:13)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #128    RenderObject.layout (package:flutter/src/rendering/object.dart:1767:7)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #129    RenderStack.layoutPositionedChild (package:flutter/src/rendering/stack.dart:487:11)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #130    RenderStack.performLayout (package:flutter/src/rendering/stack.dart:583:30)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #131    RenderObject.layout (package:flutter/src/rendering/object.dart:1767:7)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #132    _RenderLayoutBuilder.performLayout (package:flutter/src/widgets/layout_builder.dart:246:13)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #133    RenderObject.layout (package:flutter/src/rendering/object.dart:1767:7)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #134    RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:111:13)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #135    RenderObject.layout (package:flutter/src/rendering/object.dart:1767:7)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #136    RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:111:13)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #137    RenderObject.layout (package:flutter/src/rendering/object.dart:1767:7)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #138    RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:111:13)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #139    RenderObject.layout (package:flutter/src/rendering/object.dart:1767:7)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #140    RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:111:13)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #141    RenderObject.layout (package:flutter/src/rendering/object.dart:1767:7)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #142    RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:111:13)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #143    RenderObject.layout (package:flutter/src/rendering/object.dart:1767:7)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #144    RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:111:13)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #145    RenderObject.layout (package:flutter/src/rendering/object.dart:1767:7)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #146    RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:111:13)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #147    RenderObject.layout (package:flutter/src/rendering/object.dart:1767:7)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #148    RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:111:13)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #149    RenderOffstage.performLayout (package:flutter/src/rendering/proxy_box.dart:3225:13)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #150    RenderObject.layout (package:flutter/src/rendering/object.dart:1767:7)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #151    _RenderTheatre.performLayout (package:flutter/src/widgets/overlay.dart:700:15)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #152    RenderObject.layout (package:flutter/src/rendering/object.dart:1767:7)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #153    RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:111:13)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #154    RenderObject.layout (package:flutter/src/rendering/object.dart:1767:7)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #155    RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:111:13)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #156    RenderObject.layout (package:flutter/src/rendering/object.dart:1767:7)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #157    RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:111:13)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #158    RenderObject.layout (package:flutter/src/rendering/object.dart:1767:7)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #159    RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:111:13)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #160    RenderObject.layout (package:flutter/src/rendering/object.dart:1767:7)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #161    RenderProxyBoxMixin.performLayout (package:flutter/src/rendering/proxy_box.dart:111:13)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #162    RenderObject._layoutWithoutResize (package:flutter/src/rendering/object.dart:1630:7)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #163    PipelineOwner.flushLayout (package:flutter/src/rendering/object.dart:887:18)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #164    RendererBinding.drawFrame (package:flutter/src/rendering/binding.dart:402:19)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #165    WidgetsBinding.drawFrame (package:flutter/src/widgets/binding.dart:865:13)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #166    RendererBinding._handlePersistentFrameCallback (package:flutter/src/rendering/binding.dart:284:5)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #167    SchedulerBinding._invokeFrameCallback (package:flutter/src/scheduler/binding.dart:1074:15)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #168    SchedulerBinding.handleDrawFrame (package:flutter/src/scheduler/binding.dart:1013:9)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): #169    SchedulerBinding.scheduleWarmUpFrame.<anonymous closure> (package:flutter/src/scheduler/binding.dart:822:7)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): (elided 11 frames from class _RawReceivePortImpl, class _Timer, dart:async, and dart:async-patch)
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): 
[00866.212] 47871:48563> flutter_gallery.cmx(flutter): 
```