### PR TITLE
Add download links, web link, and update desktop example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,16 +41,20 @@ This includes:
 - Linux
 - Windows
 
-That being said, extra steps must be taken to [enable Desktop support](
+
+An APK, macOS, Linux, and Windows builds are available for [download](https://github.com/flutter/gallery/releases). You can find it on the web at [gallery.flutter.dev](https://gallery.flutter.dev/) and on the [Google Play Store](https://play.google.com/store/apps/details?id=io.flutter.demo.gallery).
+
+You can build from source yourself for any of these platforms, though, please note desktop support must [be enabled](
 https://github.com/flutter/flutter/wiki/Desktop-shells#tooling). For
-example, to run the macOS app:
+example, to run the app on Windows:
 
 ```bash
 cd gallery/
-flutter config --enable-macos-desktop
+flutter config --enable-windows-desktop
 flutter create .
-flutter run -d macos
+flutter run -d windows
 ```
+
 
 Additionally, the UI adapts between mobile and desktop layouts regardless of the
 platform it runs on. This is determined based on window size as outlined in

--- a/README.md
+++ b/README.md
@@ -41,7 +41,6 @@ This includes:
 - Linux
 - Windows
 
-
 An APK, macOS, Linux, and Windows builds are available for [download](https://github.com/flutter/gallery/releases). You can find it on the web at [gallery.flutter.dev](https://gallery.flutter.dev/) and on the [Google Play Store](https://play.google.com/store/apps/details?id=io.flutter.demo.gallery).
 
 You can build from source yourself for any of these platforms, though, please note desktop support must [be enabled](
@@ -54,7 +53,6 @@ flutter config --enable-windows-desktop
 flutter create .
 flutter run -d windows
 ```
-
 
 Additionally, the UI adapts between mobile and desktop layouts regardless of the
 platform it runs on. This is determined based on window size as outlined in


### PR DESCRIPTION
Updated the example to match https://github.com/flutter/flutter/wiki/Desktop-shells#tooling and because we include the macOS folder.

Closes https://github.com/flutter/gallery/issues/136