### PR TITLE
Improve crane Focus

### DIFF
--- a/lib/studies/crane/backlayer.dart
+++ b/lib/studies/crane/backlayer.dart
@@ -7,7 +7,7 @@ import 'package:flutter/material.dart';
 abstract class BackLayerItem extends StatefulWidget {
   final int index;
 
-  const BackLayerItem({Key key, this.index}) : super(key: key);
+  const BackLayerItem({Key key, @required this.index}) : super(key: key);
 }
 
 class BackLayer extends StatefulWidget {
@@ -31,19 +31,15 @@ class _BackLayerState extends State<BackLayer> {
   @override
   Widget build(BuildContext context) {
     final tabIndex = widget.tabController.index;
-    return FocusTraversalGroup(
-      policy: WidgetOrderTraversalPolicy(),
-      child: IndexedStack(
-        index: tabIndex,
-        children: [
-          for (BackLayerItem backLayerItem in widget.backLayerItems)
-            Focus(
-              canRequestFocus: backLayerItem.index == tabIndex,
-              debugLabel: 'backLayerItem: $backLayerItem',
-              child: backLayerItem,
-            )
-        ],
-      ),
+    return IndexedStack(
+      index: tabIndex,
+      children: [
+        for (BackLayerItem backLayerItem in widget.backLayerItems)
+          ExcludeFocus(
+            excluding: backLayerItem.index != tabIndex,
+            child: backLayerItem,
+          )
+      ],
     );
   }
 }

--- a/lib/studies/crane/eat_form.dart
+++ b/lib/studies/crane/eat_form.dart
@@ -9,7 +9,7 @@ import 'package:gallery/studies/crane/backlayer.dart';
 import 'package:gallery/studies/crane/header_form.dart';
 
 class EatForm extends BackLayerItem {
-  const EatForm({int index}) : super(index: 3);
+  const EatForm() : super(index: 2);
 
   @override
   _EatFormState createState() => _EatFormState();

--- a/lib/studies/crane/fly_form.dart
+++ b/lib/studies/crane/fly_form.dart
@@ -9,7 +9,7 @@ import 'package:gallery/studies/crane/backlayer.dart';
 import 'package:gallery/studies/crane/header_form.dart';
 
 class FlyForm extends BackLayerItem {
-  const FlyForm({int index}) : super(index: index);
+  const FlyForm() : super(index: 0);
 
   @override
   _FlyFormState createState() => _FlyFormState();

--- a/lib/studies/crane/model/data.dart
+++ b/lib/studies/crane/model/data.dart
@@ -17,6 +17,7 @@ List<FlyDestination> getFlyDestinations(BuildContext context) =>
         duration: const Duration(hours: 6, minutes: 15),
         assetSemanticLabel:
             GalleryLocalizations.of(context).craneFly0SemanticLabel,
+        imageAspectRatio: 400 / 400,
       ),
       FlyDestination(
         id: 1,

--- a/lib/studies/crane/sleep_form.dart
+++ b/lib/studies/crane/sleep_form.dart
@@ -9,7 +9,7 @@ import 'package:gallery/studies/crane/backlayer.dart';
 import 'package:gallery/studies/crane/header_form.dart';
 
 class SleepForm extends BackLayerItem {
-  const SleepForm({int index}) : super(index: 2);
+  const SleepForm() : super(index: 1);
 
   @override
   _SleepFormState createState() => _SleepFormState();


### PR DESCRIPTION
Now that `ExcludeFocus` is available, use it to exclude focus for the 2 unselected backlayer forms. 

Closes https://github.com/flutter/gallery/issues/28