### PR TITLE
Remove slash before Flutter path to make build happy

### DIFF
--- a/.github/workflows/golden.yml
+++ b/.github/workflows/golden.yml
@@ -18,7 +18,7 @@ jobs:
         path: 'flutter'
         fetch-depth: 0
     - name: Add Flutter to the PATH for Unix.
-      run: echo "::add-path::/$GITHUB_WORKSPACE/flutter/bin"
+      run: echo "::add-path::$GITHUB_WORKSPACE/flutter/bin"
     - name: Run Flutter doctor.
       run: flutter doctor -v
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,7 +18,7 @@ jobs:
         path: 'flutter'
         fetch-depth: 0
     - name: Add Flutter to the PATH.
-      run: echo "::add-path::/$GITHUB_WORKSPACE/flutter/bin"
+      run: echo "::add-path::$GITHUB_WORKSPACE/flutter/bin"
     - name: Run Flutter doctor.
       run: flutter doctor -v
     - name: Enable Flutter web.

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -21,7 +21,7 @@ jobs:
         path: 'flutter'
         fetch-depth: 0
     - name: Add Flutter to the PATH for Unix.
-      run: echo "::add-path::/$GITHUB_WORKSPACE/flutter/bin"
+      run: echo "::add-path::$GITHUB_WORKSPACE/flutter/bin"
       if: runner.os != 'Windows'
     - name: Add Flutter to the PATH for Windows.
       run: echo "::add-path::${env:GITHUB_WORKSPACE}\flutter\bin"


### PR DESCRIPTION
Remove slash before the path to ensure that we can build Flutter.

See reasoning from https://stackoverflow.com/questions/41187802/bug-report-issue-building-flutter-on-a-mac
