### PR TITLE
[Performance] Refactor SettingsListItem

### DIFF
--- a/lib/pages/settings.dart
+++ b/lib/pages/settings.dart
@@ -148,7 +148,7 @@ class _SettingsPageState extends State<SettingsPage> {
           context,
           useSentinel: true,
         ),
-        options: LinkedHashMap.of({
+        optionsMap: LinkedHashMap.of({
           systemTextScaleFactorOption: DisplayOption(
             GalleryLocalizations.of(context).settingsSystemDefault,
           ),
@@ -175,7 +175,7 @@ class _SettingsPageState extends State<SettingsPage> {
       SettingsListItem<CustomTextDirection>(
         title: GalleryLocalizations.of(context).settingsTextDirection,
         selectedOption: options.customTextDirection,
-        options: LinkedHashMap.of({
+        optionsMap: LinkedHashMap.of({
           CustomTextDirection.localeBased: DisplayOption(
             GalleryLocalizations.of(context).settingsTextDirectionLocaleBased,
           ),
@@ -198,7 +198,7 @@ class _SettingsPageState extends State<SettingsPage> {
         selectedOption: options.locale == deviceLocale
             ? systemLocaleOption
             : options.locale,
-        options: _getLocaleOptions(),
+        optionsMap: _getLocaleOptions(),
         onOptionChanged: (newLocale) {
           if (newLocale == systemLocaleOption) {
             newLocale = deviceLocale;
@@ -214,7 +214,7 @@ class _SettingsPageState extends State<SettingsPage> {
       SettingsListItem<TargetPlatform>(
         title: GalleryLocalizations.of(context).settingsPlatformMechanics,
         selectedOption: options.platform,
-        options: LinkedHashMap.of({
+        optionsMap: LinkedHashMap.of({
           TargetPlatform.android: DisplayOption('Android'),
           TargetPlatform.iOS: DisplayOption('iOS'),
           TargetPlatform.macOS: DisplayOption('macOS'),
@@ -231,7 +231,7 @@ class _SettingsPageState extends State<SettingsPage> {
       SettingsListItem<ThemeMode>(
         title: GalleryLocalizations.of(context).settingsTheme,
         selectedOption: options.themeMode,
-        options: LinkedHashMap.of({
+        optionsMap: LinkedHashMap.of({
           ThemeMode.system: DisplayOption(
             GalleryLocalizations.of(context).settingsSystemDefault,
           ),

--- a/lib/pages/settings_list_item.dart
+++ b/lib/pages/settings_list_item.dart
@@ -82,16 +82,9 @@ class SettingsListItem<T> extends StatefulWidget {
     @required this.onOptionChanged,
     @required this.onTapSetting,
     @required this.isExpanded,
-  })  : options = optionsMap.keys,
-        displayOptions = optionsMap.values,
-        super(key: key);
+  }) : super(key: key);
 
   final LinkedHashMap<T, DisplayOption> optionsMap;
-
-  /// For ease of use. Correspond to the keys and values of [optionsMap].
-  final Iterable<T> options;
-  final Iterable<DisplayOption> displayOptions;
-
   final String title;
   final T selectedOption;
   final ValueChanged<T> onOptionChanged;
@@ -115,6 +108,10 @@ class _SettingsListItemState<T> extends State<SettingsListItem<T>>
   Animation<EdgeInsetsGeometry> _headerPadding;
   Animation<EdgeInsetsGeometry> _childrenPadding;
   Animation<BorderRadius> _headerBorderRadius;
+
+  // For ease of use. Correspond to the keys and values of `widget.optionsMap`.
+  Iterable<T> _options;
+  Iterable<DisplayOption> _displayOptions;
 
   @override
   void initState() {
@@ -145,6 +142,9 @@ class _SettingsListItemState<T> extends State<SettingsListItem<T>>
     if (widget.isExpanded) {
       _controller.value = 1.0;
     }
+
+    _options = widget.optionsMap.keys;
+    _displayOptions = widget.optionsMap.values;
   }
 
   @override
@@ -213,11 +213,11 @@ class _SettingsListItemState<T> extends State<SettingsListItem<T>>
         ),
         child: ListView.builder(
           shrinkWrap: true,
-          itemCount: widget.isExpanded ? widget.optionsMap.keys.length : 0,
+          itemCount: widget.isExpanded ? _options.length : 0,
           itemBuilder: (context, index) {
-            final displayOption = widget.displayOptions.elementAt(index);
+            final displayOption = _displayOptions.elementAt(index);
             return RadioListTile<T>(
-              value: widget.options.elementAt(index),
+              value: _options.elementAt(index),
               title: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [

--- a/lib/pages/settings_list_item.dart
+++ b/lib/pages/settings_list_item.dart
@@ -82,10 +82,15 @@ class SettingsListItem<T> extends StatefulWidget {
     @required this.onOptionChanged,
     @required this.onTapSetting,
     @required this.isExpanded,
-  }) : super(key: key);
+  })  : optionsKeys = options.keys,
+        optionsValues = options.values,
+        super(key: key);
 
   final String title;
   final LinkedHashMap<T, DisplayOption> options;
+  // For ease of use.
+  final Iterable<T> optionsKeys;
+  final Iterable<DisplayOption> optionsValues;
   final T selectedOption;
   final ValueChanged<T> onOptionChanged;
   final Function onTapSetting;
@@ -190,46 +195,11 @@ class _SettingsListItemState<T> extends State<SettingsListItem<T>>
     _handleExpansion();
     final theme = Theme.of(context);
 
-    final optionWidgetsList = <Widget>[];
-
-    widget.options.forEach(
-      (optionValue, optionDisplay) => optionWidgetsList.add(
-        RadioListTile<T>(
-          value: optionValue,
-          title: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                optionDisplay.title,
-                style: theme.textTheme.bodyText1.copyWith(
-                  color: Theme.of(context).colorScheme.onPrimary,
-                ),
-              ),
-              if (optionDisplay.subtitle != null)
-                Text(
-                  optionDisplay.subtitle,
-                  style: theme.textTheme.bodyText1.copyWith(
-                    fontSize: 12,
-                    color: Theme.of(context)
-                        .colorScheme
-                        .onPrimary
-                        .withOpacity(0.8),
-                  ),
-                ),
-            ],
-          ),
-          groupValue: widget.selectedOption,
-          onChanged: (newOption) => widget.onOptionChanged(newOption),
-          activeColor: Theme.of(context).colorScheme.primary,
-          dense: true,
-        ),
-      ),
-    );
-
     return AnimatedBuilder(
       animation: _controller.view,
       builder: _buildHeaderWithChildren,
       child: Container(
+        constraints: const BoxConstraints(maxHeight: 380),
         margin: const EdgeInsetsDirectional.only(start: 24, bottom: 40),
         decoration: BoxDecoration(
           border: BorderDirectional(
@@ -241,9 +211,39 @@ class _SettingsListItemState<T> extends State<SettingsListItem<T>>
         ),
         child: ListView.builder(
           shrinkWrap: true,
-          physics: const NeverScrollableScrollPhysics(),
-          itemBuilder: (context, index) => optionWidgetsList[index],
-          itemCount: widget.isExpanded ? optionWidgetsList.length : 0,
+          itemCount: widget.isExpanded ? widget.options.keys.length : 0,
+          itemBuilder: (context, index) {
+            final displayOption = widget.optionsValues.elementAt(index);
+            return RadioListTile<T>(
+              value: widget.optionsKeys.elementAt(index),
+              title: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    displayOption.title,
+                    style: theme.textTheme.bodyText1.copyWith(
+                      color: Theme.of(context).colorScheme.onPrimary,
+                    ),
+                  ),
+                  if (displayOption.subtitle != null)
+                    Text(
+                      displayOption.subtitle,
+                      style: theme.textTheme.bodyText1.copyWith(
+                        fontSize: 12,
+                        color: Theme.of(context)
+                            .colorScheme
+                            .onPrimary
+                            .withOpacity(0.8),
+                      ),
+                    ),
+                ],
+              ),
+              groupValue: widget.selectedOption,
+              onChanged: (newOption) => widget.onOptionChanged(newOption),
+              activeColor: Theme.of(context).colorScheme.primary,
+              dense: true,
+            );
+          },
         ),
       ),
     );

--- a/lib/pages/settings_list_item.dart
+++ b/lib/pages/settings_list_item.dart
@@ -201,7 +201,7 @@ class _SettingsListItemState<T> extends State<SettingsListItem<T>>
       animation: _controller.view,
       builder: _buildHeaderWithChildren,
       child: Container(
-        constraints: const BoxConstraints(maxHeight: 380),
+        constraints: const BoxConstraints(maxHeight: 384),
         margin: const EdgeInsetsDirectional.only(start: 24, bottom: 40),
         decoration: BoxDecoration(
           border: BorderDirectional(

--- a/lib/pages/settings_list_item.dart
+++ b/lib/pages/settings_list_item.dart
@@ -76,21 +76,23 @@ class SlowMotionSetting extends StatelessWidget {
 class SettingsListItem<T> extends StatefulWidget {
   SettingsListItem({
     Key key,
+    @required this.optionsMap,
     @required this.title,
-    @required this.options,
     @required this.selectedOption,
     @required this.onOptionChanged,
     @required this.onTapSetting,
     @required this.isExpanded,
-  })  : optionsKeys = options.keys,
-        optionsValues = options.values,
+  })  : options = optionsMap.keys,
+        displayOptions = optionsMap.values,
         super(key: key);
 
+  final LinkedHashMap<T, DisplayOption> optionsMap;
+
+  /// For ease of use. Correspond to the keys and values of [optionsMap].
+  final Iterable<T> options;
+  final Iterable<DisplayOption> displayOptions;
+
   final String title;
-  final LinkedHashMap<T, DisplayOption> options;
-  // For ease of use.
-  final Iterable<T> optionsKeys;
-  final Iterable<DisplayOption> optionsValues;
   final T selectedOption;
   final ValueChanged<T> onOptionChanged;
   final Function onTapSetting;
@@ -174,7 +176,7 @@ class _SettingsListItemState<T> extends State<SettingsListItem<T>>
           subtitleHeight: _headerSubtitleHeight,
           chevronRotation: _headerChevronRotation,
           title: widget.title,
-          subtitle: widget.options[widget.selectedOption]?.title ?? '',
+          subtitle: widget.optionsMap[widget.selectedOption]?.title ?? '',
           onTap: () => widget.onTapSetting(),
         ),
         Padding(
@@ -211,11 +213,11 @@ class _SettingsListItemState<T> extends State<SettingsListItem<T>>
         ),
         child: ListView.builder(
           shrinkWrap: true,
-          itemCount: widget.isExpanded ? widget.options.keys.length : 0,
+          itemCount: widget.isExpanded ? widget.optionsMap.keys.length : 0,
           itemBuilder: (context, index) {
-            final displayOption = widget.optionsValues.elementAt(index);
+            final displayOption = widget.displayOptions.elementAt(index);
             return RadioListTile<T>(
-              value: widget.optionsKeys.elementAt(index),
+              value: widget.options.elementAt(index),
               title: Column(
                 crossAxisAlignment: CrossAxisAlignment.start,
                 children: [


### PR DESCRIPTION
This PR refactor SettingsListItem for performance. 
- Only creates a RadioListTile for those visible items instead of all of them
- Limits the container height so that only 8 list items can be visible at once. This really only affects the behavior for the locale setting.

Closes #46

### Web startup performance
Before | After
------------ | -------------
<img width="337" alt="before" src="https://user-images.githubusercontent.com/6655696/85072698-d0e5ab00-b1b9-11ea-927d-18df3722c926.png"> | <img width="312" alt="after" src="https://user-images.githubusercontent.com/6655696/85072782-ed81e300-b1b9-11ea-9060-207dcc2431f4.png">

<img width="483" alt="Screenshot 2020-06-18 at 23 03 53" src="https://user-images.githubusercontent.com/6655696/85072893-186c3700-b1ba-11ea-945d-a91a7f12cb37.png">
<img width="532" alt="Screenshot 2020-06-18 at 21 35 34" src="https://user-images.githubusercontent.com/6655696/85072905-1d30eb00-b1ba-11ea-95cc-1f48043c047c.png">


