### PR TITLE
Move away from deprecated API

### DIFF
--- a/lib/codeviewer/code_segments.dart
+++ b/lib/codeviewer/code_segments.dart
@@ -28160,7 +28160,7 @@ class CodeSegments {
       TextSpan(style: codeStyle.punctuationStyle, text: '>['),
       TextSpan(style: codeStyle.baseStyle, text: '\u000a                    '),
       TextSpan(
-          style: codeStyle.classStyle, text: 'WhitelistingTextInputFormatter'),
+          style: codeStyle.classStyle, text: 'FilteringTextInputFormatter'),
       TextSpan(style: codeStyle.punctuationStyle, text: '.'),
       TextSpan(style: codeStyle.baseStyle, text: 'digitsOnly'),
       TextSpan(style: codeStyle.punctuationStyle, text: ','),

--- a/lib/demos/material/text_field_demo.dart
+++ b/lib/demos/material/text_field_demo.dart
@@ -222,7 +222,7 @@ class TextFormFieldDemoState extends State<TextFormFieldDemo> {
                   validator: _validatePhoneNumber,
                   // TextInputFormatters are applied in sequence.
                   inputFormatters: <TextInputFormatter>[
-                    WhitelistingTextInputFormatter.digitsOnly,
+                    FilteringTextInputFormatter.digitsOnly,
                     // Fit the validating format.
                     _phoneNumberFormatter,
                   ],

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -77,7 +77,7 @@ packages:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.12"
+    version: "1.14.13"
   convert:
     dependency: transitive
     description:
@@ -133,7 +133,7 @@ packages:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.1.0"
+    version: "5.2.0"
   flare_dart:
     dependency: "direct main"
     description:
@@ -296,7 +296,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.6"
+    version: "0.12.8"
   meta:
     dependency: "direct main"
     description:
@@ -311,13 +311,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.9.6+3"
-  multi_server_socket:
-    dependency: transitive
-    description:
-      name: multi_server_socket
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.2"
   node_interop:
     dependency: transitive
     description:
@@ -588,21 +581,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.7"
+    version: "1.15.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.16"
+    version: "0.2.17"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.7"
+    version: "0.3.9"
   typed_data:
     dependency: transitive
     description:


### PR DESCRIPTION
`WhitelistingTextInputFormatter` is deprecated. Instead, we should use `FilteringTextInputFormatter`