### PR TITLE
Use light text theme for Fortnightly

### DIFF
--- a/integration_test/gallery_compile_test.dart
+++ b/integration_test/gallery_compile_test.dart
@@ -8,7 +8,7 @@ import 'package:test/test.dart';
 import 'package:path/path.dart' as path;
 
 // Benchmark size in kB.
-const int bundleSizeBenchmark = 4000;
+const int bundleSizeBenchmark = 4050;
 const int gzipBundleSizeBenchmark = 1000;
 
 void main() {

--- a/lib/studies/fortnightly/shared.dart
+++ b/lib/studies/fortnightly/shared.dart
@@ -565,7 +565,7 @@ ThemeData buildTheme(BuildContext context) {
       iconTheme: IconTheme.of(context).copyWith(color: Colors.black),
     ),
     highlightColor: Colors.transparent,
-    textTheme: textTheme.copyWith(
+    primaryTextTheme: textTheme.copyWith(
       // preview snippet
       bodyText2: GoogleFonts.merriweather(
         fontWeight: FontWeight.w300,

--- a/lib/studies/fortnightly/shared.dart
+++ b/lib/studies/fortnightly/shared.dart
@@ -555,9 +555,8 @@ List<Widget> buildVideoPreviewItems(BuildContext context) {
 }
 
 ThemeData buildTheme(BuildContext context) {
-  final textTheme = Theme.of(context).textTheme;
+  final lightTextTheme = ThemeData.light().textTheme;
   return ThemeData(
-    primaryColor: Colors.white,
     scaffoldBackgroundColor: Colors.white,
     appBarTheme: AppBarTheme(
       color: Colors.white,
@@ -565,25 +564,25 @@ ThemeData buildTheme(BuildContext context) {
       iconTheme: IconTheme.of(context).copyWith(color: Colors.black),
     ),
     highlightColor: Colors.transparent,
-    primaryTextTheme: textTheme.copyWith(
+    textTheme: TextTheme(
       // preview snippet
       bodyText2: GoogleFonts.merriweather(
         fontWeight: FontWeight.w300,
         fontSize: 16,
-        textStyle: textTheme.bodyText2,
+        textStyle: lightTextTheme.bodyText2,
       ),
       // time in latest updates
       bodyText1: GoogleFonts.libreFranklin(
         fontWeight: FontWeight.w500,
         fontSize: 11,
         color: Colors.black.withOpacity(0.5),
-        textStyle: textTheme.bodyText1,
+        textStyle: lightTextTheme.bodyText1,
       ),
       // preview headlines
       headline5: GoogleFonts.libreFranklin(
         fontWeight: FontWeight.w500,
         fontSize: 16,
-        textStyle: textTheme.headline5,
+        textStyle: lightTextTheme.headline5,
       ),
       // (caption 2), preview category, stock ticker
       subtitle1: GoogleFonts.robotoCondensed(
@@ -593,14 +592,14 @@ ThemeData buildTheme(BuildContext context) {
       subtitle2: GoogleFonts.libreFranklin(
         fontWeight: FontWeight.w400,
         fontSize: 14,
-        textStyle: textTheme.subtitle2,
+        textStyle: lightTextTheme.subtitle2,
       ),
       // section titles: Top Highlights, Last Updated...
       headline6: GoogleFonts.merriweather(
         fontWeight: FontWeight.w700,
         fontStyle: FontStyle.italic,
         fontSize: 14,
-        textStyle: textTheme.headline6,
+        textStyle: lightTextTheme.headline6,
       ),
     ),
   );


### PR DESCRIPTION
Always use light text theme as a base for Fortnightly to always render text in black

Before|After
---|---
<img width="500" alt="Screenshot 2020-06-30 at 11 26 10" src="https://user-images.githubusercontent.com/6655696/86109327-8c64e400-bac4-11ea-833b-110fcc863451.png"> |  <img width="500" alt="Screenshot 2020-06-30 at 11 24 19" src="https://user-images.githubusercontent.com/6655696/86109101-4c056600-bac4-11ea-92d9-0bdce8038eb1.png">
