### PR TITLE
Fix link to material time picker documentation

### DIFF
--- a/lib/data/demos.dart
+++ b/lib/data/demos.dart
@@ -523,7 +523,7 @@ List<GalleryDemo> materialDemos(GalleryLocalizations localizations) {
         GalleryDemoConfiguration(
           title: localizations.demoTimePickerTitle,
           description: localizations.demoTimePickerDescription,
-          documentationUrl: '$_docsBaseUrl/material/showTimePicker.htmlhtml',
+          documentationUrl: '$_docsBaseUrl/material/showTimePicker.html',
           buildRoute: (context) => const PickerDemo(type: PickerDemoType.time),
           code: CodeSegments.pickerDemo,
         ),


### PR DESCRIPTION
Issue: 
          https://gallery.flutter.dev/#/demo/pickers -> time picker -> API Documentation -> Page not found