### PR TITLE
Update flutter format command in unit test to use new dart_style format command

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -43,7 +43,7 @@ jobs:
       run: flutter analyze
       working-directory: code
     - name: Ensure the Dart code is formatted correctly.
-      run: flutter format --set-exit-if-changed --dry-run .
+      run: flutter format --set-exit-if-changed --output=none .
       working-directory: code
     - name: Run Flutter unit tests.
       run: flutter test


### PR DESCRIPTION
Unit tests are being broken by this change https://github.com/dart-lang/sdk/commit/d1a06cf97b833609909cd28cd5b9744a43d0e26c . Dartdev no longer exposes --dry-run, and has moved over to using dart_style new format_command library.

https://github.com/dart-lang/dart_style/commit/796742d6b65a0b8f9e66466a52f0d61e68dde330#diff-e1c081a9861acd632aeedf94281ba650 introduced a new format command library in the dart_style package. 

The argument --dry-run is no longer exposed by dartdev, and dart_style has an oldCli flag to access it. --dry-run previously analyzed all the files in the package and output a list of files that still required formatting with dartfmt, without making any changes to the files themselves. There is a new flag that is exposed by dartdev, --output=none, that accomplishes the same functionality --dry-run had. Screenshot below.

![Screen Shot 2020-07-14 at 11 56 01 PM](https://user-images.githubusercontent.com/948037/87513942-58de9980-c62e-11ea-9ede-6abff4d275e4.png)
