### PR TITLE
Add performance transitions test for crane only

### DIFF
--- a/test_driver/transitions_perf.dart
+++ b/test_driver/transitions_perf.dart
@@ -11,15 +11,17 @@ import 'package:flutter_driver/driver_extension.dart';
 import 'package:gallery/data/demos.dart';
 import 'package:gallery/main.dart' show GalleryApp;
 
+// See transitions_perf_test.dart for how to run this test.
+
 Future<String> _handleMessages(String message) async {
   switch (message) {
     case 'demoDescriptions':
       final demoDescriptions = allGalleryDemoDescriptions();
       return const JsonEncoder.withIndent('  ').convert(demoDescriptions);
-      break;
     case 'isWeb':
       return kIsWeb.toString();
-      break;
+    case 'isTestingCraneOnly':
+      return const String.fromEnvironment('onlyCrane', defaultValue: 'false');
     default:
       throw 'unknown message';
   }

--- a/test_driver/transitions_perf_test.dart
+++ b/test_driver/transitions_perf_test.dart
@@ -238,7 +238,7 @@ void main([List<String> args = const <String>[]]) {
 
       final summary = TimelineSummary.summarize(timeline);
       await summary.writeSummaryToFile('transitions-crane', pretty: true);
-    });
+    }, timeout: const Timeout(Duration(seconds: 15)));
 
     test('all demos', () async {
       if (isTestingCraneOnly) return;


### PR DESCRIPTION
Adds a test to perform the transitions test for Crane only. 

To run the transitions_perf test for all demos:
`flutter drive --profile --trace-startup -t test_driver/transitions_perf.dart -d <device>`
To run the transitions_perf test for just Crane:
`flutter drive --profile --trace-startup -t test_driver/transitions_perf.dart -d <device> --dart-define=onlyCrane=true`

Since --tags isn't yet supported for flutter driver tests and `skip` isn't designed for runtime determination, this is the simplest way to conditionally run a driver test from the command line.

Closes https://github.com/flutter/gallery/issues/214