### PR TITLE
[a11y-web] adding enabled to button semantics 

### DIFF
--- a/lib/pages/backdrop.dart
+++ b/lib/pages/backdrop.dart
@@ -298,6 +298,7 @@ class _SettingsIcon extends AnimatedWidget {
       child: Semantics(
         sortKey: const OrdinalSortKey(1),
         button: true,
+        enabled: true,
         label: _settingsSemanticLabel(isSettingsOpenNotifier.value, context),
         child: SizedBox(
           width: _settingsButtonWidth,

--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -1093,6 +1093,7 @@ class _StudyWrapperState extends State<StudyWrapper> {
                 sortKey: const OrdinalSortKey(0),
                 label: GalleryLocalizations.of(context).backToGallery,
                 button: true,
+                enabled: true,
                 excludeSemantics: true,
                 child: FloatingActionButton.extended(
                   key: const ValueKey('Back'),

--- a/lib/studies/rally/finance.dart
+++ b/lib/studies/rally/finance.dart
@@ -102,6 +102,7 @@ class FinancialEntityCategoryView extends StatelessWidget {
     return Semantics.fromProperties(
       properties: SemanticsProperties(
         button: true,
+        enabled: true,
         label: semanticsLabel,
       ),
       excludeSemantics: true,

--- a/lib/studies/shrine/category_menu_page.dart
+++ b/lib/studies/shrine/category_menu_page.dart
@@ -70,6 +70,7 @@ class CategoryMenuPage extends StatelessWidget {
       builder: (context, child, model) => Semantics(
         selected: model.selectedCategory == category,
         button: true,
+        enabled: true,
         child: GestureDetector(
           onTap: () {
             model.setCategory(category);
@@ -130,6 +131,7 @@ class CategoryMenuPage extends StatelessWidget {
                   _divider(context: context),
                   Semantics(
                     button: true,
+                    enabled: true,
                     child: GestureDetector(
                       onTap: () {
                         Navigator.of(context).pushNamed(ShrineApp.loginRoute);
@@ -175,6 +177,7 @@ class CategoryMenuPage extends StatelessWidget {
                     ),
                     Semantics(
                       button: true,
+                      enabled: true,
                       child: GestureDetector(
                         onTap: () {
                           if (onCategoryTap != null) {

--- a/lib/studies/shrine/expanding_bottom_sheet.dart
+++ b/lib/studies/shrine/expanding_bottom_sheet.dart
@@ -508,6 +508,7 @@ class _ExpandingBottomSheetState extends State<ExpandingBottomSheet>
     final childWithInteraction = productPageIsVisible(context)
         ? Semantics(
             button: true,
+            enabled: true,
             label: GalleryLocalizations.of(context)
                 .shrineScreenReaderCart(totalCartQuantity),
             child: GestureDetector(

--- a/lib/studies/shrine/shopping_cart.dart
+++ b/lib/studies/shrine/shopping_cart.dart
@@ -273,6 +273,7 @@ class ShoppingCartRow extends StatelessWidget {
             label: GalleryLocalizations.of(context)
                 .shrineScreenReaderRemoveProductButton(product.name(context)),
             button: true,
+            enabled: true,
             child: ExcludeSemantics(
               child: SizedBox(
                 width: _startColumnWidth,

--- a/lib/studies/shrine/supplemental/product_card.dart
+++ b/lib/studies/shrine/supplemental/product_card.dart
@@ -27,6 +27,7 @@ class MobileProductCard extends StatelessWidget {
     return Semantics(
       container: true,
       button: true,
+      enabled: true,
       child: _buildProductCard(
         context: context,
         product: product,


### PR DESCRIPTION
Web will add aria-disabled to these elements otherwise: https://github.com/flutter/engine/blob/master/lib/web_ui/lib/src/engine/semantics/tappable.dart#L27
