### PR TITLE
Shared y axis reverse fix

### DIFF
--- a/lib/codeviewer/code_segments.dart
+++ b/lib/codeviewer/code_segments.dart
@@ -31657,6 +31657,11 @@ class CodeSegments {
       TextSpan(style: codeStyle.classStyle, text: 'PageTransitionSwitcher'),
       TextSpan(style: codeStyle.punctuationStyle, text: '('),
       TextSpan(
+          style: codeStyle.baseStyle, text: '\u000a                reverse'),
+      TextSpan(style: codeStyle.punctuationStyle, text: ':'),
+      TextSpan(style: codeStyle.baseStyle, text: ' _isAlphabetical'),
+      TextSpan(style: codeStyle.punctuationStyle, text: ','),
+      TextSpan(
           style: codeStyle.baseStyle,
           text: '\u000a                transitionBuilder'),
       TextSpan(style: codeStyle.punctuationStyle, text: ':'),

--- a/lib/demos/reference/motion_demo_shared_y_axis_transition.dart
+++ b/lib/demos/reference/motion_demo_shared_y_axis_transition.dart
@@ -114,7 +114,6 @@ class _SharedYAxisTransitionDemoState extends State<SharedYAxisTransitionDemo>
           Expanded(
             child: Container(
               child: PageTransitionSwitcher(
-                duration: const Duration(seconds: 4),
                 reverse: _isAlphabetical,
                 transitionBuilder: (child, animation, secondaryAnimation) {
                   return SharedAxisTransition(

--- a/lib/demos/reference/motion_demo_shared_y_axis_transition.dart
+++ b/lib/demos/reference/motion_demo_shared_y_axis_transition.dart
@@ -114,6 +114,8 @@ class _SharedYAxisTransitionDemoState extends State<SharedYAxisTransitionDemo>
           Expanded(
             child: Container(
               child: PageTransitionSwitcher(
+                duration: const Duration(seconds: 4),
+                reverse: _isAlphabetical,
                 transitionBuilder: (child, animation, secondaryAnimation) {
                   return SharedAxisTransition(
                     child: child,


### PR DESCRIPTION
This fixes #234 

Before|After
---|---
![before-shared-y-axis](https://user-images.githubusercontent.com/948037/88837459-2768e080-d18d-11ea-9403-8f4609e158ba.gif) | ![reverse-shared-y-axis](https://user-images.githubusercontent.com/948037/88837671-49626300-d18d-11ea-875d-26f3f123fc65.gif)


