### PR TITLE
Enable external view embedder on iOS to test benchmark

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -170,5 +170,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>io.flutter.embedded_views_preview</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
After rolling https://github.com/flutter/engine/pull/19919 into the framework, we enabled dynamic thread merging on iOS. Which means enabling the external view embedder will still keep raster thread and platform thread separate until there are platform views on the scene.
Which then means the performance should be relatively unchanged just by enabling the external view embedder on gallery.

This PR enables the external view embedder on iOS so we can watch for the benchmark.