### PR TITLE
Increase Crane performance test timeout

### DIFF
--- a/test_driver/transitions_perf_test.dart
+++ b/test_driver/transitions_perf_test.dart
@@ -248,7 +248,7 @@ void main([List<String> args = const <String>[]]) {
 
       final summary = TimelineSummary.summarize(timeline);
       await summary.writeSummaryToFile('transitions-crane', pretty: true);
-    }, timeout: const Timeout(Duration(seconds: 15)));
+    }, timeout: const Timeout(Duration(seconds: 60)));
 
     test('all demos', () async {
       if (isTestingCraneOnly) return;


### PR DESCRIPTION
See https://github.com/flutter/flutter/issues/64328#issuecomment-678412127

We'll need to also roll the new gallery version in https://github.com/flutter/flutter/blob/master/dev/devicelab/lib/versions/gallery.dart to have Flutter use this.