### PR TITLE
Update cupertino_icons to 1.0.0

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -126,7 +126,7 @@ packages:
       name: cupertino_icons
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0-dev.4"
+    version: "1.0.0"
   dart_style:
     dependency: transitive
     description:
@@ -738,4 +738,4 @@ packages:
     version: "2.2.1"
 sdks:
   dart: ">=2.10.0-4.0.dev <2.10.0"
-  flutter: ">=1.22.0-2.0.0 <2.0.0"
+  flutter: ">=1.17.0 <2.0.0"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -126,7 +126,7 @@ packages:
       name: cupertino_icons
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "1.0.0-dev.4"
   dart_style:
     dependency: transitive
     description:
@@ -738,4 +738,4 @@ packages:
     version: "2.2.1"
 sdks:
   dart: ">=2.10.0-4.0.dev <2.10.0"
-  flutter: ">=1.17.0 <2.0.0"
+  flutter: ">=1.22.0-2.0.0 <2.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   intl: ^0.16.1
   flutter_localized_locales: ^1.1.1
-  cupertino_icons: ^0.1.3
+  cupertino_icons: ^1.0.0-dev.4
   rally_assets: ^2.0.0
   meta: ^1.1.8
   scoped_model: ^1.0.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
     sdk: flutter
   intl: ^0.16.1
   flutter_localized_locales: ^1.1.1
-  cupertino_icons: ^1.0.0-dev.4
+  cupertino_icons: ^1.0.0
   rally_assets: ^2.0.0
   meta: ^1.1.8
   scoped_model: ^1.0.1


### PR DESCRIPTION
I'm trying to update flutter/flutter to cupertino_icons to 1.0.0. But due to https://github.com/flutter/gallery/issues/254#issuecomment-686697714, I need to update flutter/gallery first since it's upstream to be able to enforce the one version rule in flutter/flutter

https://github.com/flutter/flutter/issues/33916