### PR TITLE
[gen_l10n] Fix preferred-supported-locales to use yaml sequence

### DIFF
--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,5 +1,6 @@
 template-arb-file: intl_en.arb
 output-localization-file: gallery_localizations.dart
 output-class: GalleryLocalizations
-preferred-supported-locales: '["en"]'
+preferred-supported-locales:
+  - en
 use-deferred-loading: true


### PR DESCRIPTION
https://github.com/flutter/flutter/pull/63649 makes a breaking change that allows the list of preferred locales to be expressed as a yaml sequence instead of a json string. For example, in `l10n.yaml`, this:
```
preferred-supported-locales: '["en", "es"]'
```

is now be represented like this: 
```
preferred-supported-locales:
  - en
  - es
```
or
```
preferred-supported-locales: [en, es]
```