### PR TITLE
[Reply] Use clipBehavior instead of deprecated overflow parameter in Reply Stack

### DIFF
--- a/lib/studies/reply/adaptive_nav.dart
+++ b/lib/studies/reply/adaptive_nav.dart
@@ -650,7 +650,7 @@ class _MobileNavState extends State<_MobileNav> with TickerProviderStateMixin {
     ).animate(_drawerCurve);
 
     return Stack(
-      overflow: Overflow.visible,
+      clipBehavior: Clip.none,
       key: _bottomDrawerKey,
       children: [
         NotificationListener<ScrollNotification>(


### PR DESCRIPTION
This change adds a fix for a breaking change: https://github.com/flutter/flutter/commit/7948a7863bd8931e4e029c5b109f26c1b3dcf8ea