### PR TITLE
Unhide gradient

### DIFF
--- a/lib/codeviewer/code_segments.dart
+++ b/lib/codeviewer/code_segments.dart
@@ -37089,8 +37089,6 @@ class CodeSegments {
       TextSpan(
           style: codeStyle.stringStyle,
           text: '\u0027package:flutter/material.dart\u0027'),
-      TextSpan(style: codeStyle.baseStyle, text: ' hide '),
-      TextSpan(style: codeStyle.classStyle, text: 'Gradient'),
       TextSpan(style: codeStyle.punctuationStyle, text: ';'),
       TextSpan(style: codeStyle.baseStyle, text: '\u000a'),
       TextSpan(style: codeStyle.keywordStyle, text: 'import'),

--- a/lib/demos/reference/transformations_demo_board.dart
+++ b/lib/demos/reference/transformations_demo_board.dart
@@ -5,7 +5,7 @@
 import 'dart:collection' show IterableMixin;
 import 'dart:math';
 import 'dart:ui' show Vertices;
-import 'package:flutter/material.dart' hide Gradient;
+import 'package:flutter/material.dart';
 import 'package:vector_math/vector_math_64.dart' show Vector3;
 
 // BEGIN transformationsDemo#2


### PR DESCRIPTION
Remove `hide Gradient` from the import directive in `reference/transformations_demo_board.dart`.

## Explanation
The file `reference/transformations_demo_board.dart` imports `package:flutter/material.dart` and hides `Gradient`, but `Gradient` is never defined or used in the file, so removing it should have no effect.

We make this change so that the DartPad code generator can handle import directives better.
