### PR TITLE
Remove useTextSelectionTheme from gallery.

### DIFF
--- a/lib/studies/crane/theme.dart
+++ b/lib/studies/crane/theme.dart
@@ -35,7 +35,6 @@ ThemeData _buildCraneTheme() {
       textTheme: ButtonTextTheme.accent,
     ),
     textTheme: _buildCraneTextTheme(base.textTheme),
-    useTextSelectionTheme: true,
     textSelectionTheme: const TextSelectionThemeData(
       selectionColor: cranePurple700,
     ),

--- a/lib/studies/shrine/theme.dart
+++ b/lib/studies/shrine/theme.dart
@@ -41,7 +41,6 @@ ThemeData _buildShrineTheme() {
       contentPadding: EdgeInsets.symmetric(vertical: 20, horizontal: 16),
     ),
     textTheme: _buildShrineTextTheme(base.textTheme),
-    useTextSelectionTheme: true,
     textSelectionTheme: const TextSelectionThemeData(
       selectionColor: shrinePink100,
     ),

--- a/lib/themes/material_demo_theme_data.dart
+++ b/lib/themes/material_demo_theme_data.dart
@@ -33,7 +33,6 @@ class MaterialDemoThemeData {
     typography: Typography.material2018(
       platform: defaultTargetPlatform,
     ),
-    useTextSelectionTheme: true,
   );
 
   static const _colorScheme = ColorScheme(


### PR DESCRIPTION
Now that the second step of the [TextSelectionTheme migration](https://github.com/flutter/flutter/pull/65044) as landed, we need to remove the no longer needed reference to the `useTextSelectionTheme` property.
