### PR TITLE
Use new format to add env path in Github Actions

### DIFF
--- a/.github/workflows/golden.yml
+++ b/.github/workflows/golden.yml
@@ -18,7 +18,7 @@ jobs:
         path: 'flutter'
         fetch-depth: 0
     - name: Add Flutter to the PATH for Unix
-      run: echo "::add-path::$GITHUB_WORKSPACE/flutter/bin"
+      run: echo "$GITHUB_WORKSPACE/flutter/bin" >> $GITHUB_PATH
     - name: Run Flutter doctor
       run: flutter doctor -v
 

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -18,7 +18,7 @@ jobs:
         path: 'flutter'
         fetch-depth: 0
     - name: Add Flutter to the PATH
-      run: echo "::add-path::$GITHUB_WORKSPACE/flutter/bin"
+      run: echo "$GITHUB_WORKSPACE/flutter/bin" >> $GITHUB_PATH
     - name: Run Flutter doctor
       run: flutter doctor -v
     - name: Enable Flutter web

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,10 +54,10 @@ jobs:
         fetch-depth: 0
     - name: Add Flutter to the PATH for Linux and macOS
       if: startsWith(matrix.os, 'macOS') || startsWith(matrix.os, 'ubuntu')
-      run: echo "::add-path::$GITHUB_WORKSPACE/flutter/bin"
+      run: echo "$GITHUB_WORKSPACE/flutter/bin" >> $GITHUB_PATH
     - name: Add Flutter to the PATH for Windows
       if: startsWith(matrix.os, 'windows')
-      run: echo "::add-path::${env:GITHUB_WORKSPACE}\flutter\bin"
+      run: echo "${env:GITHUB_WORKSPACE}\flutter\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Install Linux dependencies
       if: startsWith(matrix.target, 'linux')
       run: |

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -22,10 +22,10 @@ jobs:
         fetch-depth: 0
     - name: Add Flutter to the PATH for Unix
       if: startsWith(matrix.os, 'macOS') || startsWith(matrix.os, 'ubuntu')
-      run: echo "::add-path::$GITHUB_WORKSPACE/flutter/bin"
+      run: echo "$GITHUB_WORKSPACE/flutter/bin" >> $GITHUB_PATH
     - name: Add Flutter to the PATH for Windows
       if: startsWith(matrix.os, 'windows')
-      run: echo "::add-path::${env:GITHUB_WORKSPACE}\flutter\bin"
+      run: echo "${env:GITHUB_WORKSPACE}\flutter\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
     - name: Run Flutter doctor
       run: flutter doctor -v
 


### PR DESCRIPTION
The old way is deprecated: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/.

From [documentation](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#adding-a-system-path) this is the new way.

Closes https://github.com/flutter/gallery/issues/345