### PR TITLE
Update scoped_model to 1.1.0

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -478,7 +478,7 @@ packages:
       name: scoped_model
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0"
   shared_preferences:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   cupertino_icons: ^1.0.0
   rally_assets: ^2.0.0
   meta: ^1.1.8
-  scoped_model: ^1.0.1
+  scoped_model: ^1.1.0
   shrine_images: ^1.1.2
   flare_dart: ^2.3.4
   flare_flutter: ^2.0.2


### PR DESCRIPTION
This version of scoped_model has migrated deprecated API that we intend to remove soon.
Changelog: https://pub.dev/packages/scoped_model/changelog
Reference: https://github.com/flutter/flutter/pull/67789
