### PR TITLE
Only use deferred loading when building the web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ flutter pub run grinder update-code-segments
 
 3. Publish the firebase hosted web release.
     * Log in to the account that has write access to `gallery-flutter-dev` with `firebase login`
-    * `flutter build web`
+    * `flutter pub run grinder build-web`
     * `firebase deploy -P prod` to deploy to production (equivalent to `firebase deploy`).
     * `firebase deploy -P staging` to deploy to staging. Check with the team to see if the staging
        instance is currently used for a special purpose.

--- a/integration_test/gallery_compile_test.dart
+++ b/integration_test/gallery_compile_test.dart
@@ -21,11 +21,10 @@ void main() {
         'main.dart.js',
       );
       await _runProcess('flutter', [
-        'build',
-        'web',
-        '-v',
-        '--release',
-        '--no-pub',
+        'pub',
+        'run',
+        'grinder',
+        'build-web',
       ]);
       await _runProcess('gzip', ['-k', js]);
       final bundleSize = await _measureSize(js);

--- a/l10n.yaml
+++ b/l10n.yaml
@@ -3,4 +3,4 @@ output-localization-file: gallery_localizations.dart
 output-class: GalleryLocalizations
 preferred-supported-locales:
   - en
-use-deferred-loading: true
+use-deferred-loading: false

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -581,7 +581,7 @@ packages:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.2"
+    version: "1.10.0-nullsafety.4"
   stream_channel:
     dependency: transitive
     description:
@@ -744,5 +744,5 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.10.0-110 <=2.11.0-207.0.dev"
+  dart: ">=2.10.0-110 <=2.11.0-240.0.dev"
   flutter: ">=1.17.0 <2.0.0"

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -94,6 +94,10 @@ Future<void> verifyCodeSegments() async {
   }
 }
 
+// TODO(perclasson): Work around to let us build the web version with deferred
+// loading. When Flutter supports using different yaml files in different
+// environments, this should be updated:
+// https://github.com/flutter/flutter/issues/69023.
 @Task('Build web')
 Future<void> buildWeb({String directory}) async {
   final fileName = 'l10n.yaml';

--- a/tool/grind.dart
+++ b/tool/grind.dart
@@ -94,6 +94,19 @@ Future<void> verifyCodeSegments() async {
   }
 }
 
+@Task('Build web')
+Future<void> buildWeb({String directory}) async {
+  final fileName = 'l10n.yaml';
+  final originalContents = await File(fileName).readAsString();
+  final newContents = originalContents.replaceAll(
+    RegExp(r'use-deferred-loading: false'),
+    'use-deferred-loading: true',
+  );
+  await File(fileName).writeAsString(newContents);
+  await _runProcess('flutter', ['build', 'web']);
+  await File(fileName).writeAsString(originalContents);
+}
+
 Future<void> _runProcess(String executable, List<String> arguments) async {
   final result = await Process.run(executable, arguments);
   stdout.write(result.stdout);


### PR DESCRIPTION
Currently we get warnings when working on the Gallery, that deferred loading causes hot reload to not work. We actually only want deferred loading to be used in the release version of the Gallery on web.

Closes https://github.com/flutter/gallery/issues/357