### PR TITLE
Temporarily remove shared_preferences dependency until it can be used with nnbd

### DIFF
--- a/golden_test/flutter_test_config.dart
+++ b/golden_test/flutter_test_config.dart
@@ -5,7 +5,6 @@
 import 'dart:async';
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
 import 'testing/font_loader.dart';
 
@@ -23,7 +22,8 @@ Future<void> testExecutable(FutureOr<void> Function() testMain) async {
   // Disabling the warning because @visibleForTesting doesn't take the testing
   // framework into account.
   // ignore: invalid_use_of_visible_for_testing_member
-  SharedPreferences.setMockInitialValues(<String, String>{});
+  // TODO(rami-a): Re-enable once shared_preferences is migrated to NNBD.
+//  SharedPreferences.setMockInitialValues(<String, String>{});
   await loadFonts();
   await testMain();
 }

--- a/golden_test/flutter_test_config.dart
+++ b/golden_test/flutter_test_config.dart
@@ -22,8 +22,7 @@ Future<void> testExecutable(FutureOr<void> Function() testMain) async {
   // Disabling the warning because @visibleForTesting doesn't take the testing
   // framework into account.
   // ignore: invalid_use_of_visible_for_testing_member
-  // TODO(rami-a): Re-enable once shared_preferences is migrated to NNBD.
-//  SharedPreferences.setMockInitialValues(<String, String>{});
+  // TODO(rami-a): Add back shared_preferences mocking once migrated to NNBD.
   await loadFonts();
   await testMain();
 }

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -4,8 +4,6 @@ PODS:
     - Flutter
   - path_provider (0.0.1):
     - Flutter
-  - shared_preferences (0.0.1):
-    - Flutter
   - url_launcher (0.0.1):
     - Flutter
 
@@ -13,7 +11,6 @@ DEPENDENCIES:
   - Flutter (from `Flutter`)
   - package_info (from `.symlinks/plugins/package_info/ios`)
   - path_provider (from `.symlinks/plugins/path_provider/ios`)
-  - shared_preferences (from `.symlinks/plugins/shared_preferences/ios`)
   - url_launcher (from `.symlinks/plugins/url_launcher/ios`)
 
 EXTERNAL SOURCES:
@@ -23,16 +20,13 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/package_info/ios"
   path_provider:
     :path: ".symlinks/plugins/path_provider/ios"
-  shared_preferences:
-    :path: ".symlinks/plugins/shared_preferences/ios"
   url_launcher:
     :path: ".symlinks/plugins/url_launcher/ios"
 
 SPEC CHECKSUMS:
-  Flutter: 0e3d915762c693b495b44d77113d4970485de6ec
+  Flutter: 434fef37c0980e73bb6479ef766c45957d4b510c
   package_info: 873975fc26034f0b863a300ad47e7f1ac6c7ec62
   path_provider: abfe2b5c733d04e238b0d8691db0cfd63a27a93c
-  shared_preferences: af6bfa751691cdc24be3045c43ec037377ada40d
   url_launcher: 6fef411d543ceb26efce54b05a0a40bfd74cbbef
 
 PODFILE CHECKSUM: aafe91acc616949ddb318b77800a7f51bffa2a4c

--- a/lib/pages/demo.dart
+++ b/lib/pages/demo.dart
@@ -18,10 +18,10 @@ import 'package:gallery/layout/adaptive.dart';
 import 'package:gallery/pages/splash.dart';
 import 'package:gallery/themes/gallery_theme_data.dart';
 import 'package:google_fonts/google_fonts.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-const _demoViewedCountKey = 'demoViewedCountKey';
+// TODO(rami-a): Re-enable once shared_preferences is migrated to NNBD.
+//const _demoViewedCountKey = 'demoViewedCountKey';
 
 enum _DemoState {
   normal,
@@ -132,12 +132,14 @@ class _GalleryDemoPageState extends State<GalleryDemoPage>
       vsync: this,
       duration: const Duration(milliseconds: 300),
     );
-    SharedPreferences.getInstance().then((preferences) {
-      setState(() {
-        _demoViewedCount = preferences.getInt(_demoViewedCountKey) ?? 0;
-        preferences.setInt(_demoViewedCountKey, _demoViewedCount + 1);
-      });
-    });
+    // TODO(rami-a): Re-enable once shared_preferences is migrated to NNBD.
+    _demoViewedCount = 10;
+//    SharedPreferences.getInstance().then((preferences) {
+//      setState(() {
+//        _demoViewedCount = preferences.getInt(_demoViewedCountKey) ?? 0;
+//        preferences.setInt(_demoViewedCountKey, _demoViewedCount + 1);
+//      });
+//    });
   }
 
   @override

--- a/lib/pages/demo.dart
+++ b/lib/pages/demo.dart
@@ -20,9 +20,6 @@ import 'package:gallery/themes/gallery_theme_data.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'package:url_launcher/url_launcher.dart';
 
-// TODO(rami-a): Re-enable once shared_preferences is migrated to NNBD.
-//const _demoViewedCountKey = 'demoViewedCountKey';
-
 enum _DemoState {
   normal,
   options,
@@ -132,14 +129,8 @@ class _GalleryDemoPageState extends State<GalleryDemoPage>
       vsync: this,
       duration: const Duration(milliseconds: 300),
     );
-    // TODO(rami-a): Re-enable once shared_preferences is migrated to NNBD.
+    // TODO(rami-a): Add back shared_preferences check once migrated to NNBD.
     _demoViewedCount = 10;
-//    SharedPreferences.getInstance().then((preferences) {
-//      setState(() {
-//        _demoViewedCount = preferences.getInt(_demoViewedCountKey) ?? 0;
-//        preferences.setInt(_demoViewedCountKey, _demoViewedCount + 1);
-//      });
-//    });
   }
 
   @override

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,12 +7,10 @@ import Foundation
 
 import package_info
 import path_provider_macos
-import shared_preferences_macos
 import url_launcher_macos
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FLTPackageInfoPlugin.register(with: registry.registrar(forPlugin: "FLTPackageInfoPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
-  SharedPreferencesPlugin.register(with: registry.registrar(forPlugin: "SharedPreferencesPlugin"))
   UrlLauncherPlugin.register(with: registry.registrar(forPlugin: "UrlLauncherPlugin"))
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -437,48 +437,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0"
-  shared_preferences:
-    dependency: "direct main"
-    description:
-      name: shared_preferences
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.5.12+4"
-  shared_preferences_linux:
-    dependency: transitive
-    description:
-      name: shared_preferences_linux
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.0.2+4"
-  shared_preferences_macos:
-    dependency: transitive
-    description:
-      name: shared_preferences_macos
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.0.1+11"
-  shared_preferences_platform_interface:
-    dependency: transitive
-    description:
-      name: shared_preferences_platform_interface
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.4"
-  shared_preferences_web:
-    dependency: transitive
-    description:
-      name: shared_preferences_web
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.1.2+7"
-  shared_preferences_windows:
-    dependency: transitive
-    description:
-      name: shared_preferences_windows
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.0.1+3"
   shelf:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,7 +20,6 @@ dependencies:
   shrine_images: ^1.1.2
   url_launcher: ^5.6.0
   vector_math: ^2.0.8
-  shared_preferences: ^0.5.4
   collection: ^1.14.0
   flutter_gallery_assets: ^0.2.6
   package_info: ^0.4.0


### PR DESCRIPTION
This is to unblock the NNBD migration for flutter