### PR TITLE
State restorable fortnightly

### DIFF
--- a/lib/layout/image_placeholder.dart
+++ b/lib/layout/image_placeholder.dart
@@ -11,7 +11,7 @@ import 'package:flutter/material.dart';
 /// to specify a widget as a [placeholder], instead of just an [ImageProvider].
 /// It also lets you override the [child] argument, in case you want to wrap
 /// the image with another widget, for example an [Ink.image].
-class FadeInImagePlaceholder extends StatefulWidget {
+class FadeInImagePlaceholder extends StatelessWidget {
   const FadeInImagePlaceholder({
     Key key,
     @required this.image,
@@ -55,47 +55,20 @@ class FadeInImagePlaceholder extends StatefulWidget {
   final BoxFit fit;
 
   @override
-  _FadeInImagePlaceholderState createState() => _FadeInImagePlaceholderState();
-}
-
-class _FadeInImagePlaceholderState extends State<FadeInImagePlaceholder> {
-  bool _isLoaded = false;
-
-  @override
-  void initState() {
-    super.initState();
-    // Once the image is loaded, we no longer need to show a placeholder
-    widget.image
-        .resolve(ImageConfiguration.empty)
-        .addListener(ImageStreamListener(
-      (imageInfo, synchronousCall) {
-        setState(() {
-          _isLoaded = true;
-        });
-      },
-    ));
-  }
-
-  @override
   Widget build(BuildContext context) {
     return Image(
-      image: widget.image,
-      excludeFromSemantics: widget.excludeFromSemantics,
-      width: widget.width,
-      height: widget.height,
-      fit: widget.fit,
+      image: image,
+      excludeFromSemantics: excludeFromSemantics,
+      width: width,
+      height: height,
+      fit: fit,
       frameBuilder: (context, child, frame, wasSynchronouslyLoaded) {
-        // We only need to animate the loading of images on the web. We can
-        // also return early if the images are already in the cache.
-        if (wasSynchronouslyLoaded || !kIsWeb) {
-          if (!_isLoaded) {
-            return widget.placeholder;
-          }
-          return widget.child ?? child;
+        if (wasSynchronouslyLoaded) {
+          return this.child ?? child;
         } else {
           return AnimatedSwitcher(
-            duration: widget.duration,
-            child: frame != null ? widget.child ?? child : widget.placeholder,
+            duration: duration,
+            child: frame != null ? this.child ?? child : placeholder,
           );
         }
       },

--- a/lib/layout/image_placeholder.dart
+++ b/lib/layout/image_placeholder.dart
@@ -63,6 +63,7 @@ class _FadeInImagePlaceholderState extends State<FadeInImagePlaceholder> {
 
   @override
   void initState() {
+    super.initState();
     // Once the image is loaded, we no longer need to show a placeholder
     widget.image
         .resolve(ImageConfiguration.empty)
@@ -73,7 +74,6 @@ class _FadeInImagePlaceholderState extends State<FadeInImagePlaceholder> {
         });
       },
     ));
-    super.initState();
   }
 
   @override

--- a/lib/studies/fortnightly/app.dart
+++ b/lib/studies/fortnightly/app.dart
@@ -24,6 +24,7 @@ class FortnightlyApp extends StatelessWidget {
         ? const _FortnightlyHomeDesktop()
         : const _FortnightlyHomeMobile();
     return MaterialApp(
+      restorationScopeId: 'appNavigator',
       title: _fortnightlyTitle,
       debugShowCheckedModeBanner: false,
       theme: buildTheme(context).copyWith(
@@ -76,6 +77,7 @@ class _FortnightlyHomeMobile extends StatelessWidget {
       ),
       body: SafeArea(
         child: ListView(
+          restorationId: 'list_view',
           children: [
             HashtagBar(),
             for (final item in buildArticlePreviewItems(context))

--- a/lib/studies/fortnightly/app.dart
+++ b/lib/studies/fortnightly/app.dart
@@ -24,7 +24,7 @@ class FortnightlyApp extends StatelessWidget {
         ? const _FortnightlyHomeDesktop()
         : const _FortnightlyHomeMobile();
     return MaterialApp(
-      restorationScopeId: 'appNavigator',
+      restorationScopeId: 'fortnightly_app',
       title: _fortnightlyTitle,
       debugShowCheckedModeBanner: false,
       theme: buildTheme(context).copyWith(

--- a/lib/studies/fortnightly/shared.dart
+++ b/lib/studies/fortnightly/shared.dart
@@ -244,6 +244,7 @@ class HashtagBar extends StatelessWidget {
     return SizedBox(
       height: height,
       child: ListView(
+        restorationId: 'hashtag_bar_list_view',
         scrollDirection: Axis.horizontal,
         children: [
           const SizedBox(width: 16),


### PR DESCRIPTION
Just a few `ListView`s. The horizontal ListView is fine, however, I noticed that the vertical ListView's scroll offset isn't properly restored. Also, the asset images flicker upon state restoration. A similar issue is happening for the Reply mini app as well.

My guess is that the images need to be loaded when the app is restored, but at the first layout, they're not available and result in the offset being restored incorrectly. ~If this is really the case, is there a way to wait for the images to load before building the ListView? I stumbled upon [this flutter issue](https://github.com/flutter/flutter/issues/26127) while looking for clues.~

Another solution could be to put a placeholder in place before the asset image is available, but it's weird because [FadeInImagePlaceholder](https://github.com/flutter/gallery/blob/master/lib/layout/image_placeholder.dart#L14) should already be doing this? I'm not too familiar with images so I'm not exactly sure what's going on here.

Edit: I ended up modifying the code so that it uses a placeholder when the asset image is not loaded yet. PTAL