### PR TITLE
State Restorable starter app

### DIFF
--- a/lib/studies/starter/app.dart
+++ b/lib/studies/starter/app.dart
@@ -17,6 +17,7 @@ class StarterApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
+      restorationScopeId: 'appNavigator',
       title: GalleryLocalizations.of(context).starterAppTitle,
       debugShowCheckedModeBanner: false,
       localizationsDelegates: GalleryLocalizations.localizationsDelegates,

--- a/lib/studies/starter/app.dart
+++ b/lib/studies/starter/app.dart
@@ -17,7 +17,7 @@ class StarterApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
-      restorationScopeId: 'appNavigator',
+      restorationScopeId: 'starter_app',
       title: GalleryLocalizations.of(context).starterAppTitle,
       debugShowCheckedModeBanner: false,
       localizationsDelegates: GalleryLocalizations.localizationsDelegates,


### PR DESCRIPTION
Not much to do here -- Once drawers are state restorable in the framework (see https://github.com/flutter/flutter/issues/70925), this should automatically pick that up. Otherwise, this will prepare the starter app for any future state restoration additions to the mini app.

Related to https://github.com/flutter/flutter/issues/62916