### PR TITLE
Disable web benchmarks

### DIFF
--- a/test/benchmarks_test.dart
+++ b/test/benchmarks_test.dart
@@ -21,6 +21,7 @@ final valueList = <String>[
 
 /// Tests that the Gallery web benchmarks are run and reported correctly.
 Future<void> main() async {
+  // See https://github.com/flutter/gallery/issues/411 for why it is skipped.
   test('Can run a web benchmark', () async {
     print('Starting web benchmark tests ...');
 
@@ -28,6 +29,7 @@ Future<void> main() async {
       benchmarkAppDirectory: projectRootDirectory(),
       entryPoint: 'test/benchmarks/client.dart',
       useCanvasKit: false,
+      headless: true,
     );
 
     print('Web benchmark tests finished.');
@@ -63,5 +65,5 @@ Future<void> main() async {
       const JsonEncoder.withIndent('  ').convert(taskResult.toJson()),
       isA<String>(),
     );
-  }, timeout: Timeout.none);
+  }, timeout: Timeout.none, skip: true);
 }


### PR DESCRIPTION
Seems like web benchmarks started failing unusually. It's not clear what's changed, but I want to skip the test for now to unblock other work, if that's okay.

GitHub issue: https://github.com/flutter/gallery/issues/411