### PR TITLE
Update transitions_perf_test.dart

### DIFF
--- a/test_driver/transitions_perf_test.dart
+++ b/test_driver/transitions_perf_test.dart
@@ -266,7 +266,7 @@ void main([List<String> args = const <String>[]]) {
       );
 
       final summary = TimelineSummary.summarize(timeline);
-      await summary.writeSummaryToFile('transitions-crane', pretty: true);
+      await summary.writeTimelineToFile('transitions-crane', pretty: true);
     }, timeout: Timeout.none);
 
     test('only Reply', () async {


### PR DESCRIPTION
This method is being deprecated in https://github.com/flutter/flutter/pull/79310

The new method will still write the summary, but also always writes the full timeline in case summarization fails.