### PR TITLE
Remove the AnimatedSize vsync parameter

### DIFF
--- a/lib/pages/demo.dart
+++ b/lib/pages/demo.dart
@@ -405,7 +405,6 @@ class _GalleryDemoPageState extends State<GalleryDemoPage>
       );
     } else {
       section = AnimatedSize(
-        vsync: this,
         duration: const Duration(milliseconds: 200),
         alignment: Alignment.topCenter,
         curve: Curves.easeIn,

--- a/lib/studies/shrine/expanding_bottom_sheet.dart
+++ b/lib/studies/shrine/expanding_bottom_sheet.dart
@@ -132,8 +132,7 @@ double _getPeakPoint({double begin, double end}) {
   return begin + (end - begin) * _peakVelocityProgress;
 }
 
-class _ExpandingBottomSheetState extends State<ExpandingBottomSheet>
-    with TickerProviderStateMixin {
+class _ExpandingBottomSheetState extends State<ExpandingBottomSheet> {
   final GlobalKey _expandingBottomSheetKey =
       GlobalKey(debugLabel: 'Expanding bottom sheet');
 
@@ -556,7 +555,6 @@ class _ExpandingBottomSheetState extends State<ExpandingBottomSheet>
       key: _expandingBottomSheetKey,
       duration: const Duration(milliseconds: 225),
       curve: Curves.easeInOut,
-      vsync: this,
       alignment: AlignmentDirectional.topStart,
       child: AnimatedBuilder(
         animation: widget.hideController,


### PR DESCRIPTION
This is needed in order to land https://github.com/flutter/flutter/pull/80554,
which will deprecate AnimatedSize.vsync