### PR TITLE
Removed accentColor and buttonTheme references

### DIFF
--- a/lib/studies/crane/theme.dart
+++ b/lib/studies/crane/theme.dart
@@ -22,7 +22,6 @@ ThemeData _buildCraneTheme() {
       primary: cranePurple800,
       secondary: craneRed700,
     ),
-    accentColor: cranePurple700,
     primaryColor: cranePurple800,
     buttonColor: craneRed700,
     hintColor: craneWhite60,
@@ -31,15 +30,11 @@ ThemeData _buildCraneTheme() {
     cardColor: cranePrimaryWhite,
     errorColor: craneErrorOrange,
     highlightColor: Colors.transparent,
-    buttonTheme: const ButtonThemeData(
-      textTheme: ButtonTextTheme.accent,
-    ),
     textTheme: _buildCraneTextTheme(base.textTheme),
     textSelectionTheme: const TextSelectionThemeData(
       selectionColor: cranePurple700,
     ),
     primaryTextTheme: _buildCraneTextTheme(base.primaryTextTheme),
-    accentTextTheme: _buildCraneTextTheme(base.accentTextTheme),
     iconTheme: _customIconTheme(base.iconTheme, craneWhite60),
     primaryIconTheme: _customIconTheme(base.iconTheme, cranePrimaryWhite),
   );

--- a/lib/studies/reply/app.dart
+++ b/lib/studies/reply/app.dart
@@ -147,7 +147,6 @@ class _RestorableEmailState extends RestorableListenable<EmailStore> {
 ThemeData _buildReplyLightTheme(BuildContext context) {
   final base = ThemeData.light();
   return base.copyWith(
-    accentColor: ReplyColors.orange500,
     bottomAppBarColor: ReplyColors.blue700,
     bottomSheetTheme: BottomSheetThemeData(
       backgroundColor: ReplyColors.blue700,
@@ -195,7 +194,6 @@ ThemeData _buildReplyLightTheme(BuildContext context) {
 ThemeData _buildReplyDarkTheme(BuildContext context) {
   final base = ThemeData.dark();
   return base.copyWith(
-    accentColor: ReplyColors.orange300,
     bottomAppBarColor: ReplyColors.darkBottomAppBarBackground,
     bottomSheetTheme: BottomSheetThemeData(
       backgroundColor: ReplyColors.darkDrawerBackground,

--- a/lib/studies/shrine/theme.dart
+++ b/lib/studies/shrine/theme.dart
@@ -29,10 +29,6 @@ ThemeData _buildShrineTheme() {
     scaffoldBackgroundColor: shrineBackgroundWhite,
     cardColor: shrineBackgroundWhite,
     errorColor: shrineErrorRed,
-    buttonTheme: const ButtonThemeData(
-      colorScheme: _shrineColorScheme,
-      textTheme: ButtonTextTheme.normal,
-    ),
     primaryIconTheme: _customIconTheme(base.iconTheme),
     inputDecorationTheme: const InputDecorationTheme(
       border: CutCornersBorder(

--- a/lib/themes/gallery_theme_data.dart
+++ b/lib/themes/gallery_theme_data.dart
@@ -33,7 +33,6 @@ class GalleryThemeData {
       canvasColor: colorScheme.background,
       scaffoldBackgroundColor: colorScheme.background,
       highlightColor: Colors.transparent,
-      accentColor: colorScheme.primary,
       focusColor: focusColor,
       snackBarTheme: SnackBarThemeData(
         behavior: SnackBarBehavior.floating,

--- a/lib/themes/material_demo_theme_data.dart
+++ b/lib/themes/material_demo_theme_data.dart
@@ -15,16 +15,11 @@ class MaterialDemoThemeData {
     bottomAppBarTheme: BottomAppBarTheme(
       color: _colorScheme.primary,
     ),
-    buttonTheme: const ButtonThemeData(
-      textTheme: ButtonTextTheme.primary,
-      colorScheme: _colorScheme,
-    ),
     canvasColor: _colorScheme.background,
     toggleableActiveColor: _colorScheme.primary,
     highlightColor: Colors.transparent,
     indicatorColor: _colorScheme.onPrimary,
     primaryColor: _colorScheme.primary,
-    accentColor: _colorScheme.primary,
     backgroundColor: Colors.white,
     scaffoldBackgroundColor: _colorScheme.background,
     snackBarTheme: const SnackBarThemeData(


### PR DESCRIPTION
Removed references to ThemeData accentColor, accentTextTheme, and buttonTheme because they're about to be deprecated.  This should have no effect on the gallery, since the material library no longer depends on any of the accent properties.

The ThemeData accent properties will be deprecated in https://github.com/flutter/flutter/pull/81336. The ButtonTheme PR is TBD.