### PR TITLE
Removed obsolete references to ThemeData.buttonColor

### DIFF
--- a/lib/studies/crane/theme.dart
+++ b/lib/studies/crane/theme.dart
@@ -22,7 +22,6 @@ ThemeData _buildCraneTheme() {
       secondary: craneRed700,
     ),
     primaryColor: cranePurple800,
-    buttonColor: craneRed700,
     hintColor: craneWhite60,
     indicatorColor: cranePrimaryWhite,
     scaffoldBackgroundColor: cranePrimaryWhite,

--- a/lib/studies/shrine/theme.dart
+++ b/lib/studies/shrine/theme.dart
@@ -24,7 +24,6 @@ ThemeData _buildShrineTheme() {
     appBarTheme: const AppBarTheme(brightness: Brightness.light, elevation: 0),
     colorScheme: _shrineColorScheme,
     primaryColor: shrinePink100,
-    buttonColor: shrinePink100,
     scaffoldBackgroundColor: shrineBackgroundWhite,
     cardColor: shrineBackgroundWhite,
     errorColor: shrineErrorRed,


### PR DESCRIPTION
The ThemeData.buttonColor is no longer used. This change will enable deprecating it in https://github.com/flutter/flutter/pull/82196