### PR TITLE
Fix[study-wrapper]: Back button overlapping

### DIFF
--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -1126,9 +1126,11 @@ class StudyWrapper extends StatefulWidget {
     Key key,
     this.study,
     this.alignment = AlignmentDirectional.bottomStart,
+    this.hasBottomNavBar = false,
   }) : super(key: key);
 
   final Widget study;
+  final bool hasBottomNavBar;
   final AlignmentDirectional alignment;
 
   @override
@@ -1154,7 +1156,11 @@ class _StudyWrapperState extends State<StudyWrapper> {
             child: Align(
               alignment: widget.alignment,
               child: Padding(
-                padding: const EdgeInsets.all(16),
+                padding: EdgeInsets.symmetric(
+                    horizontal: 16.0,
+                    vertical: widget.hasBottomNavBar
+                        ? kBottomNavigationBarHeight + 16.0
+                        : 16.0),
                 child: Semantics(
                   sortKey: const OrdinalSortKey(0),
                   label: GalleryLocalizations.of(context).backToGallery,

--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -83,7 +83,8 @@ class RouteConfiguration {
     Path(
         r'^' + reply_routes.homeRoute,
         // ignore: prefer_const_constructors
-        (context, match) => StudyWrapper(study: reply.ReplyApp())),
+        (context, match) =>
+            const StudyWrapper(study: reply.ReplyApp(), hasBottomNavBar: true)),
     Path(
       r'^' + starter_app_routes.defaultRoute,
       (context, match) => const StudyWrapper(


### PR DESCRIPTION
This PR fixes the overlapping "Back" button with the bottom navigation bar problem.

<p align="center">
<img src="https://user-images.githubusercontent.com/32459935/121188584-8e552c80-c869-11eb-9bef-f702c9e1fe92.jpg" width="500" />
</p>

I am not really happy with my solution because it does not cover the case where the bottom bar is no longer there (when the user scrolls and when we are in desktop display).
I would love to get your feedback and know how I could improve this.