### PR TITLE
Disable desktop scrollbars

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -51,7 +51,8 @@ class GalleryApp extends StatelessWidget {
             // ScrollBehavior. This overrides that. All vertical scrollables in
             // the gallery need to be audited before enabling this feature,
             // see https://github.com/flutter/gallery/issues/523
-            scrollBehavior: const MaterialScrollBehavior().copyWith(scrollbars: false),
+            scrollBehavior:
+                const MaterialScrollBehavior().copyWith(scrollbars: false),
             restorationScopeId: 'rootGallery',
             title: 'Flutter Gallery',
             debugShowCheckedModeBanner: false,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -47,6 +47,11 @@ class GalleryApp extends StatelessWidget {
       child: Builder(
         builder: (context) {
           return MaterialApp(
+            // By default on desktop, scrollbars are applied by the
+            // ScrollBehavior. This overrides that. All vertical scrollables in
+            // the gallery need to be audited before enabling this feature,
+            // see https://github.com/flutter/gallery/issues/523
+            scrollBehavior: const MaterialScrollBehavior().copyWith(scrollbars: false),
             restorationScopeId: 'rootGallery',
             title: 'Flutter Gallery',
             debugShowCheckedModeBanner: false,


### PR DESCRIPTION
See https://github.com/flutter/gallery/issues/523

On desktop, scrollbars are applied automatically by the scroll behavior. Currently,  most vertical scroll views in the gallery app are all using the same primary scroll controller. This causes a crash when users try to interact with the scrollbars. This change will disable the automatic scrollbars to eliminate the crash while we audit and fix up all of the scrollables in the gallery that are using the same scroll controller.