### PR TITLE
Remove desktop scrollbars from shrine

### DIFF
--- a/lib/studies/shrine/app.dart
+++ b/lib/studies/shrine/app.dart
@@ -152,6 +152,12 @@ class _ShrineAppState extends State<ShrineApp>
       child: WillPopScope(
         onWillPop: _onWillPop,
         child: MaterialApp(
+          // By default on desktop, scrollbars are applied by the
+          // ScrollBehavior. This overrides that. All vertical scrollables in
+          // the gallery need to be audited before enabling this feature,
+          // see https://github.com/flutter/gallery/issues/523
+          scrollBehavior:
+              const MaterialScrollBehavior().copyWith(scrollbars: false),
           restorationScopeId: 'shrineApp',
           title: 'Shrine',
           debugShowCheckedModeBanner: false,

--- a/lib/studies/shrine/app.dart
+++ b/lib/studies/shrine/app.dart
@@ -155,7 +155,7 @@ class _ShrineAppState extends State<ShrineApp>
           // By default on desktop, scrollbars are applied by the
           // ScrollBehavior. This overrides that. All vertical scrollables in
           // the gallery need to be audited before enabling this feature,
-          // see https://github.com/flutter/gallery/issues/523
+          // see https://github.com/flutter/gallery/issues/541
           scrollBehavior:
               const MaterialScrollBehavior().copyWith(scrollbars: false),
           restorationScopeId: 'shrineApp',


### PR DESCRIPTION
This prevents the Shrine app from crashing on desktop due to scrollbars and too many scroll views connected to the same scroll controller.
Fixes https://github.com/flutter/gallery/issues/541