### PR TITLE
Make index.html compatible with older Safari

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -72,7 +72,7 @@
             if (!reg.active && (reg.installing || reg.waiting)) {
               // No active web worker and we have installed or are installing
               // one for the first time. Simply wait for it to activate.
-              waitForActivation(reg.installing ?? reg.waiting);
+              waitForActivation(reg.installing || reg.waiting);
             } else if (!reg.active.scriptURL.endsWith(serviceWorkerVersion)) {
               // When the app updates the serviceWorkerVersion changes, so we
               // need to ask the service worker to update.


### PR DESCRIPTION
The `??` syntax is not supported by Safari older than 13.