### PR TITLE
Only use supported locales.

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -70,9 +70,9 @@ class GalleryApp extends StatelessWidget {
             initialRoute: initialRoute,
             supportedLocales: GalleryLocalizations.supportedLocales,
             locale: GalleryOptions.of(context).locale,
-            localeResolutionCallback: (locale, supportedLocales) {
-              deviceLocale = locale;
-              return locale;
+            localeListResolutionCallback: (locales, supportedLocales) {
+              deviceLocale = locales.first;
+              return basicLocaleListResolution(locales, supportedLocales);
             },
             onGenerateRoute: RouteConfiguration.onGenerateRoute,
           );


### PR DESCRIPTION
The previous implementation would sometimes select locales that were not actually supported. For example, on my desktop machine it selected "C_UTF-8".
