### PR TITLE
Fix dart null check

### DIFF
--- a/lib/feature_discovery/feature_discovery.dart
+++ b/lib/feature_discovery/feature_discovery.dart
@@ -221,7 +221,7 @@ class _FeatureDiscoveryState extends State<FeatureDiscovery>
   Widget build(BuildContext context) {
     return LayoutBuilder(builder: (ctx, _) {
       if (overlay != null) {
-        SchedulerBinding.instance.addPostFrameCallback((_) {
+        SchedulerBinding.instance?.addPostFrameCallback((_) {
           // [OverlayEntry] needs to be explicitly rebuilt when necessary.
           overlay!.markNeedsBuild();
         });
@@ -237,7 +237,7 @@ class _FeatureDiscoveryState extends State<FeatureDiscovery>
           // complete.
           FeatureDiscoveryController.of(ctx).lock();
 
-          SchedulerBinding.instance.addPostFrameCallback((_) {
+          SchedulerBinding.instance?.addPostFrameCallback((_) {
             setState(() {
               overlay = entry;
               status = FeatureDiscoveryStatus.closed;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -35,7 +35,7 @@ packages:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.8"
+    version: "3.1.6"
   args:
     dependency: "direct dev"
     description:
@@ -268,7 +268,7 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.3"
   lints:
     dependency: transitive
     description:
@@ -380,7 +380,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.0"
   path_provider:
     dependency: transitive
     description:
@@ -644,21 +644,21 @@ packages:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.20.1"
+    version: "1.19.5"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.8"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.11"
+    version: "0.4.9"
   typed_data:
     dependency: transitive
     description:
@@ -793,5 +793,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.16.0-100.0.dev <3.0.0"
+  dart: ">=2.14.0 <3.0.0"
   flutter: ">=2.6.0-0"


### PR DESCRIPTION
fix Error: Method 'addPostFrameCallback' cannot be called on 'SchedulerBinding?' because it is potentially null.