### PR TITLE
Reenable web benchmarks

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -35,7 +35,7 @@ packages:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.8"
+    version: "3.1.11"
   args:
     dependency: "direct dev"
     description:
@@ -296,7 +296,7 @@ packages:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.3"
+    version: "0.1.4"
   meta:
     dependency: "direct main"
     description:
@@ -602,7 +602,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -728,7 +728,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   vm_service:
     dependency: transitive
     description:
@@ -746,10 +746,10 @@ packages:
   web_benchmarks:
     dependency: "direct dev"
     description:
-      name: web_benchmarks
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.0.5"
+      path: "../packages/packages/web_benchmarks"
+      relative: true
+    source: path
+    version: "0.0.7"
   web_socket_channel:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -42,11 +42,7 @@ dev_dependencies:
   path: ^1.8.0
   string_scanner: ^1.1.0
   test: ^1.16.8
-  web_benchmarks: ^0.0.5
-
-dependency_overrides:
-  web_benchmarks:
-    path: ../packages/packages/web_benchmarks
+  web_benchmarks: ^0.0.7
 
 flutter:
   deferred-components:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -44,6 +44,10 @@ dev_dependencies:
   test: ^1.16.8
   web_benchmarks: ^0.0.5
 
+dependency_overrides:
+  web_benchmarks:
+    path: ../packages/packages/web_benchmarks
+
 flutter:
   deferred-components:
     - name: crane

--- a/test_benchmarks/benchmarks/gallery_automator.dart
+++ b/test_benchmarks/benchmarks/gallery_automator.dart
@@ -4,7 +4,7 @@
 
 // @dart=2.9
 
-// import 'dart:io';
+// ignore_for_file:avoid_print
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test_benchmarks/benchmarks/gallery_automator.dart
+++ b/test_benchmarks/benchmarks/gallery_automator.dart
@@ -4,7 +4,7 @@
 
 // @dart=2.9
 
-import 'dart:io';
+// import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -87,13 +87,13 @@ class GalleryAutomator {
   Future<void> automateDemoGestures() async {
     await warmUp();
 
-    stdout.writeln('==== List of demos to be run ====');
+    print('==== List of demos to be run ====');
     for (final demo in demoNames) {
       if (shouldRunPredicate(demo)) {
-        stdout.writeln(demo);
+        print(demo);
       }
     }
-    stdout.writeln('==== End of list of demos to be run ====');
+    print('==== End of list of demos to be run ====');
 
     var finishedStudyDemos = false;
 
@@ -121,7 +121,7 @@ class GalleryAutomator {
       // satisfying `runCriterion`, because we need to scroll
       // through every `Scrollable` to find the `demoButton`.
       if (shouldRunPredicate(demo)) {
-        stdout.writeln('Running demo "$demo"');
+        print('Running demo "$demo"');
 
         for (var i = 0; i < 2; ++i) {
           await controller.tap(find.byKey(ValueKey(demo)));
@@ -139,7 +139,7 @@ class GalleryAutomator {
       }
     }
 
-    stdout.writeln('All demos finished.');
+    print('All demos finished.');
 
     // At the end of the test, mark as finished.
     finished = true;
@@ -149,7 +149,7 @@ class GalleryAutomator {
   Future<void> automateScrolls() async {
     await warmUp();
 
-    stdout.writeln('Running scrolling test.');
+    print('Running scrolling test.');
 
     final selectedDemos = firstDemosOfCategories(demoNames);
 
@@ -182,13 +182,13 @@ class GalleryAutomator {
       }
     }
 
-    stdout.writeln('Scrolling test finished.');
+    print('Scrolling test finished.');
     finished = true;
   }
 
   /// Warm up the animation.
   Future<void> warmUp() async {
-    stdout.writeln('Warming up.');
+    print('Warming up.');
 
     await pumpDeferredLibraries();
 
@@ -231,7 +231,7 @@ class GalleryAutomator {
     // When warm-up finishes, inform the recorder.
     stopWarmingUpCallback();
 
-    stdout.writeln('Warm-up finished.');
+    print('Warm-up finished.');
   }
 
   /// A function to find the category of a demo.

--- a/test_benchmarks/benchmarks_test.dart
+++ b/test_benchmarks/benchmarks_test.dart
@@ -27,9 +27,6 @@ Future<void> main() async {
   test('Can run a web benchmark', () async {
     stdout.writeln('Starting web benchmark tests ...');
 
-    // TODO(pennzht): Re-enable this test, https://github.com/flutter/gallery/issues/463.
-    // return;
-    // ignore: dead_code
     final taskResult = await serveWebBenchmark(
       benchmarkAppDirectory: projectRootDirectory(),
       entryPoint: 'test_benchmarks/benchmarks/client.dart',

--- a/test_benchmarks/benchmarks_test.dart
+++ b/test_benchmarks/benchmarks_test.dart
@@ -28,7 +28,7 @@ Future<void> main() async {
     stdout.writeln('Starting web benchmark tests ...');
 
     // TODO(pennzht): Re-enable this test, https://github.com/flutter/gallery/issues/463.
-    return;
+    // return;
     // ignore: dead_code
     final taskResult = await serveWebBenchmark(
       benchmarkAppDirectory: projectRootDirectory(),


### PR DESCRIPTION
This PR uses the recently released `web_benchmarks: 0.0.7` that supports Chrome 89+ to reenable the web benchmarks here.

There was also a problem in the `gallery_automator.dart` file, that used `dart:io` to print output to `stdout`. `dart:io` methods cannot be called in a browser, and the benchmarks failed.

I removed the dependency on dart:io from that file, and replaced `stdout.writeln` by `print` calls. I had to `ignore_for_file:avoid_print` because the analyzer thinks that the code I'm touching is "production", when it should be detected as tests. 

* Fixes https://github.com/flutter/gallery/issues/463

This is what I get when I run the benchmarks in my machine (looks good, but I need to run each of the tests separately. If I do `flutter test test_benchmarks`, there seems to be some race condition that makes the benchmarks to never finish (?):

```
$ flutter test test_benchmarks/web_bundle_size_test.dart 

01:40 +0: Web Compile bundle size
Shell: 
Shell: Building without sound null safety
Shell: For more information see https://dart.dev/null-safety/unsound-null-safety
Shell: 
Shell: Compiling lib/main.dart for the Web...                             89.3s
01:41 +0: Web Compile bundle size
Shell: 4108	/usr/local/google/home/dit/github/flutter_gallery/build/web/main.dart.js
Shell: 1008	/usr/local/google/home/dit/github/flutter_gallery/build/web/main.dart.js.gz
01:41 +1: All tests passed!

----

$ flutter test test_benchmarks/benchmarks_test.dart 

00:02 +0: Can run a web benchmark
Shell: Starting web benchmark tests ...
01:34 +0: Can run a web benchmark                                                                                                      
Launching Chrome.
Launching Google Chrome 98.0.4758.102 

Waiting for the benchmark to report benchmark profile.
[CHROME]: 
[CHROME]: DevTools listening on ws://127.0.0.1:10000/devtools/browser/6514abc1-d1dd-4d74-9e7e-0f2a8c7d9a1d
Connecting to DevTools: ws://localhost:10000/devtools/page/FD8EBB697EF7C84538458956D5AF5609
Connected to Chrome tab:  (http://localhost:9999/index.html)
Launching benchmark "gallery_v2_studies_perf"
[APP] Warming up.
[APP] Warm-up finished.
[APP] ==== List of demos to be run ====
[APP] shrine@study
[APP] rally@study
[APP] crane@study
[APP] fortnightly@study
[APP] reply@study
[APP] starter@study
[APP] ==== End of list of demos to be run ====
[APP] Running demo "shrine@study"
[APP] Running demo "rally@study"
[APP] Running demo "crane@study"
[APP] Running demo "fortnightly@study"
[APP] Running demo "reply@study"
[APP] Running demo "starter@study"
[APP] All demos finished.
Extracted 572 measured frames.
Skipped 123 non-measured frames.
Launching benchmark "gallery_v2_unanimated_perf"
[APP] Warming up.
[APP] Warm-up finished.
[APP] ==== List of demos to be run ====
[APP] app-bar@material
[APP] banner@material
[APP] bottom-app-bar@material
[APP] bottom-navigation@material
[APP] bottom-sheet@material
[APP] button@material
[APP] card@material
[APP] chip@material
[APP] data-table@material
[APP] dialog@material
[APP] divider@material
[APP] grid-lists@material
[APP] lists@material
[APP] menu@material
[APP] nav_drawer@material
[APP] nav_rail@material
[APP] pickers@material
[APP] selection-controls@material
[APP] sliders@material
[APP] snackbars@material
[APP] tabs@material
[APP] text-field@material
[APP] tooltip@material
[APP] cupertino-alerts@cupertino
[APP] cupertino-buttons@cupertino
[APP] cupertino-context-menu@cupertino
[APP] cupertino-navigation-bar@cupertino
[APP] cupertino-picker@cupertino
[APP] cupertino-pull-to-refresh@cupertino
[APP] cupertino-segmented-control@cupertino
[APP] cupertino-slider@cupertino
[APP] cupertino-switch@cupertino
[APP] cupertino-tab-bar@cupertino
[APP] cupertino-text-field@cupertino
[APP] motion@other
[APP] colors@other
[APP] typography@other
[APP] 2d-transformations@other
[APP] ==== End of list of demos to be run ====
[APP] Running demo "app-bar@material"
[APP] Running demo "banner@material"
[APP] Running demo "bottom-app-bar@material"
[APP] Running demo "bottom-navigation@material"
[APP] Running demo "bottom-sheet@material"
[APP] Running demo "button@material"
[APP] Running demo "card@material"
[APP] Running demo "chip@material"
[APP] Running demo "data-table@material"
[APP] Running demo "dialog@material"
[APP] Running demo "divider@material"
[APP] Running demo "grid-lists@material"
[APP] Running demo "lists@material"
[APP] Running demo "menu@material"
[APP] Running demo "nav_drawer@material"
[APP] Running demo "nav_rail@material"
[APP] Running demo "pickers@material"
[APP] Running demo "selection-controls@material"
[APP] Running demo "sliders@material"
[APP] Running demo "snackbars@material"
[APP] Running demo "tabs@material"
[APP] Running demo "text-field@material"
[APP] Running demo "tooltip@material"
[APP] Running demo "cupertino-alerts@cupertino"
[APP] Running demo "cupertino-buttons@cupertino"
[APP] Running demo "cupertino-context-menu@cupertino"
[APP] Running demo "cupertino-navigation-bar@cupertino"
[APP] Running demo "cupertino-picker@cupertino"
[APP] Running demo "cupertino-pull-to-refresh@cupertino"
[APP] Running demo "cupertino-segmented-control@cupertino"
[APP] Running demo "cupertino-slider@cupertino"
[APP] Running demo "cupertino-switch@cupertino"
[APP] Running demo "cupertino-tab-bar@cupertino"
[APP] Running demo "cupertino-text-field@cupertino"
[APP] Running demo "motion@other"
[APP] Running demo "colors@other"
[APP] Running demo "typography@other"
[APP] Running demo "2d-transformations@other"
[APP] All demos finished.
Extracted 3076 measured frames.
Skipped 131 non-measured frames.
Launching benchmark "gallery_v2_animated_perf"
[APP] Warming up.
[APP] Warm-up finished.
[APP] ==== List of demos to be run ====
[APP] progress-indicator@material
[APP] cupertino-activity-indicator@cupertino
[APP] ==== End of list of demos to be run ====
[APP] Running demo "progress-indicator@material"
[APP] Running demo "cupertino-activity-indicator@cupertino"
[APP] All demos finished.
Extracted 849 measured frames.
Skipped 127 non-measured frames.
Launching benchmark "gallery_v2_scroll_perf"
[APP] Warming up.
[APP] Warm-up finished.
[APP] Running scrolling test.
[APP] Scrolling test finished.
Extracted 388 measured frames.
Skipped 132 non-measured frames.
Received profile data
Shell: Web benchmark tests finished.
03:25 +1: All tests passed!
```

_**PS:** I think this PR should be text-exempt, since it's reenabling a bunch of benchmarks._

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
