### PR TITLE
update deprecated window property accesses

### DIFF
--- a/test_goldens/testing/util.dart
+++ b/test_goldens/testing/util.dart
@@ -33,7 +33,7 @@ Future<void> setUpBinding(
 }) async {
   tester.binding.window.physicalSizeTestValue = size;
   tester.binding.window.devicePixelRatioTestValue = 1.0;
-  tester.binding.window.textScaleFactorTestValue = 1.0;
-  tester.binding.window.platformBrightnessTestValue = brightness;
+  tester.binding.window.platformDispatcher.textScaleFactorTestValue = 1.0;
+  tester.binding.window.platformDispatcher.platformBrightnessTestValue = brightness;
   addTearDown(tester.binding.window.clearAllTestValues);
 }

--- a/test_goldens/testing/util.dart
+++ b/test_goldens/testing/util.dart
@@ -34,6 +34,7 @@ Future<void> setUpBinding(
   tester.binding.window.physicalSizeTestValue = size;
   tester.binding.window.devicePixelRatioTestValue = 1.0;
   tester.binding.window.platformDispatcher.textScaleFactorTestValue = 1.0;
-  tester.binding.window.platformDispatcher.platformBrightnessTestValue = brightness;
+  tester.binding.window.platformDispatcher.platformBrightnessTestValue =
+      brightness;
   addTearDown(tester.binding.window.clearAllTestValues);
 }


### PR DESCRIPTION
The Dart SDK bots are currently failing due to deprecated member accesses:

```
Running "flutter pub get" in gallery...                         
   15.2s
+ /b/s/w/ir/cache/builder/sdk/out/ReleaseX64/dart-sdk/bin/dart analyze --fatal-infos
Analyzing gallery...

   info - test_goldens/testing/util.dart:36:25 - 'textScaleFactorTestValue' is deprecated and shouldn't be used. Use platformDispatcher.textScaleFactorTestValue instead. This feature was deprecated after v2.11.0-0.0.pre.. Try replacing the use of the deprecated member with the replacement. - deprecated_member_use
   info - test_goldens/testing/util.dart:37:25 - 'platformBrightnessTestValue' is deprecated and shouldn't be used. Use platformDispatcher.platformBrightnessTestValue instead. This feature was deprecated after v2.11.0-0.0.pre.. Try replacing the use of the deprecated member with the replacement. - deprecated_member_use

2 issues found.

```

See: https://logs.chromium.org/logs/dart/buildbucket/cr-buildbucket/8820350444085541905/+/u/analyze_flutter_gallery/stdout

This should fix them up.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
