### PR TITLE
Add analytics to web

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,4 +1,7 @@
 {
+  "projects": {
+    "gallery": "gallery-flutter-dev"
+  },
   "targets": {
     "gallery-flutter-dev": {
       "hosting": {

--- a/web/index.html
+++ b/web/index.html
@@ -44,6 +44,16 @@
     var serviceWorkerVersion = null;
   </script>
   <script src="flutter.js" defer></script>
+
+  <!-- Global site tag (gtag.js) - Google Analytics -->
+  <script async src="https://www.googletagmanager.com/gtag/js?id=G-MSPWFZR4VM"></script>
+  <script>
+    window.dataLayer = window.dataLayer || [];
+    function gtag() { dataLayer.push(arguments); }
+    gtag('js', new Date());
+
+    gtag('config', 'G-MSPWFZR4VM');
+  </script>
 </head>
 <body>
 


### PR DESCRIPTION
This adds a gtag.js (web only, `index.html`), with results on GA. Collects only the most basic data about access based on IP: city, date, and time.

Closes #636