### PR TITLE
Migrate ThemeData.toggleableActiveColor

### DIFF
--- a/lib/themes/material_demo_theme_data.dart
+++ b/lib/themes/material_demo_theme_data.dart
@@ -28,6 +28,24 @@ class MaterialDemoThemeData {
       platform: defaultTargetPlatform,
     ),
     visualDensity: VisualDensity.standard,
+    checkboxTheme: CheckboxThemeData(
+      fillColor: MaterialStateProperty.resolveWith<Color?>((states) {
+        return states.contains(MaterialState.selected) ? Colors.black : null;
+      }),
+    ),
+    radioTheme: RadioThemeData(
+      fillColor: MaterialStateProperty.resolveWith<Color?>((states) {
+        return states.contains(MaterialState.selected) ? Colors.black : null;
+      }),
+    ),
+    switchTheme: SwitchThemeData(
+      thumbColor: MaterialStateProperty.resolveWith<Color?>((states) {
+        return states.contains(MaterialState.selected) ? Colors.black : null;
+      }),
+      trackColor: MaterialStateProperty.resolveWith<Color?>((states) {
+        return states.contains(MaterialState.selected) ? Colors.black : null;
+      }),
+    )
   );
 
   static const _colorScheme = ColorScheme(

--- a/lib/themes/material_demo_theme_data.dart
+++ b/lib/themes/material_demo_theme_data.dart
@@ -30,20 +30,20 @@ class MaterialDemoThemeData {
     visualDensity: VisualDensity.standard,
     checkboxTheme: CheckboxThemeData(
       fillColor: MaterialStateProperty.resolveWith<Color?>((states) {
-        return states.contains(MaterialState.selected) ? Colors.black : null;
+        return states.contains(MaterialState.selected) ? _colorScheme.primary : null;
       }),
     ),
     radioTheme: RadioThemeData(
       fillColor: MaterialStateProperty.resolveWith<Color?>((states) {
-        return states.contains(MaterialState.selected) ? Colors.black : null;
+        return states.contains(MaterialState.selected) ? _colorScheme.primary : null;
       }),
     ),
     switchTheme: SwitchThemeData(
       thumbColor: MaterialStateProperty.resolveWith<Color?>((states) {
-        return states.contains(MaterialState.selected) ? Colors.black : null;
+        return states.contains(MaterialState.selected) ? _colorScheme.primary : null;
       }),
       trackColor: MaterialStateProperty.resolveWith<Color?>((states) {
-        return states.contains(MaterialState.selected) ? Colors.black : null;
+        return states.contains(MaterialState.selected) ? _colorScheme.primary : null;
       }),
     )
   );

--- a/lib/themes/material_demo_theme_data.dart
+++ b/lib/themes/material_demo_theme_data.dart
@@ -16,7 +16,6 @@ class MaterialDemoThemeData {
       color: _colorScheme.primary,
     ),
     canvasColor: _colorScheme.background,
-    toggleableActiveColor: _colorScheme.primary,
     highlightColor: Colors.transparent,
     indicatorColor: _colorScheme.onPrimary,
     primaryColor: _colorScheme.primary,

--- a/lib/themes/material_demo_theme_data.dart
+++ b/lib/themes/material_demo_theme_data.dart
@@ -8,6 +8,17 @@ import 'package:flutter/material.dart';
 class MaterialDemoThemeData {
   static final themeData = ThemeData(
       colorScheme: _colorScheme,
+      canvasColor: _colorScheme.background,
+      highlightColor: Colors.transparent,
+      indicatorColor: _colorScheme.onPrimary,
+      primaryColor: _colorScheme.primary,
+      backgroundColor: Colors.white,
+      scaffoldBackgroundColor: _colorScheme.background,
+      typography: Typography.material2018(
+        platform: defaultTargetPlatform,
+      ),
+      visualDensity: VisualDensity.standard,
+      // Component themes
       appBarTheme: AppBarTheme(
         color: _colorScheme.primary,
         iconTheme: IconThemeData(color: _colorScheme.onPrimary),
@@ -15,19 +26,6 @@ class MaterialDemoThemeData {
       bottomAppBarTheme: BottomAppBarTheme(
         color: _colorScheme.primary,
       ),
-      canvasColor: _colorScheme.background,
-      highlightColor: Colors.transparent,
-      indicatorColor: _colorScheme.onPrimary,
-      primaryColor: _colorScheme.primary,
-      backgroundColor: Colors.white,
-      scaffoldBackgroundColor: _colorScheme.background,
-      snackBarTheme: const SnackBarThemeData(
-        behavior: SnackBarBehavior.floating,
-      ),
-      typography: Typography.material2018(
-        platform: defaultTargetPlatform,
-      ),
-      visualDensity: VisualDensity.standard,
       checkboxTheme: CheckboxThemeData(
         fillColor: MaterialStateProperty.resolveWith<Color?>((states) {
           return states.contains(MaterialState.selected)
@@ -41,6 +39,9 @@ class MaterialDemoThemeData {
               ? _colorScheme.primary
               : null;
         }),
+      ),
+      snackBarTheme: const SnackBarThemeData(
+        behavior: SnackBarBehavior.floating,
       ),
       switchTheme: SwitchThemeData(
         thumbColor: MaterialStateProperty.resolveWith<Color?>((states) {

--- a/lib/themes/material_demo_theme_data.dart
+++ b/lib/themes/material_demo_theme_data.dart
@@ -7,46 +7,53 @@ import 'package:flutter/material.dart';
 
 class MaterialDemoThemeData {
   static final themeData = ThemeData(
-    colorScheme: _colorScheme,
-    appBarTheme: AppBarTheme(
-      color: _colorScheme.primary,
-      iconTheme: IconThemeData(color: _colorScheme.onPrimary),
-    ),
-    bottomAppBarTheme: BottomAppBarTheme(
-      color: _colorScheme.primary,
-    ),
-    canvasColor: _colorScheme.background,
-    highlightColor: Colors.transparent,
-    indicatorColor: _colorScheme.onPrimary,
-    primaryColor: _colorScheme.primary,
-    backgroundColor: Colors.white,
-    scaffoldBackgroundColor: _colorScheme.background,
-    snackBarTheme: const SnackBarThemeData(
-      behavior: SnackBarBehavior.floating,
-    ),
-    typography: Typography.material2018(
-      platform: defaultTargetPlatform,
-    ),
-    visualDensity: VisualDensity.standard,
-    checkboxTheme: CheckboxThemeData(
-      fillColor: MaterialStateProperty.resolveWith<Color?>((states) {
-        return states.contains(MaterialState.selected) ? _colorScheme.primary : null;
-      }),
-    ),
-    radioTheme: RadioThemeData(
-      fillColor: MaterialStateProperty.resolveWith<Color?>((states) {
-        return states.contains(MaterialState.selected) ? _colorScheme.primary : null;
-      }),
-    ),
-    switchTheme: SwitchThemeData(
-      thumbColor: MaterialStateProperty.resolveWith<Color?>((states) {
-        return states.contains(MaterialState.selected) ? _colorScheme.primary : null;
-      }),
-      trackColor: MaterialStateProperty.resolveWith<Color?>((states) {
-        return states.contains(MaterialState.selected) ? _colorScheme.primary : null;
-      }),
-    )
-  );
+      colorScheme: _colorScheme,
+      appBarTheme: AppBarTheme(
+        color: _colorScheme.primary,
+        iconTheme: IconThemeData(color: _colorScheme.onPrimary),
+      ),
+      bottomAppBarTheme: BottomAppBarTheme(
+        color: _colorScheme.primary,
+      ),
+      canvasColor: _colorScheme.background,
+      highlightColor: Colors.transparent,
+      indicatorColor: _colorScheme.onPrimary,
+      primaryColor: _colorScheme.primary,
+      backgroundColor: Colors.white,
+      scaffoldBackgroundColor: _colorScheme.background,
+      snackBarTheme: const SnackBarThemeData(
+        behavior: SnackBarBehavior.floating,
+      ),
+      typography: Typography.material2018(
+        platform: defaultTargetPlatform,
+      ),
+      visualDensity: VisualDensity.standard,
+      checkboxTheme: CheckboxThemeData(
+        fillColor: MaterialStateProperty.resolveWith<Color?>((states) {
+          return states.contains(MaterialState.selected)
+              ? _colorScheme.primary
+              : null;
+        }),
+      ),
+      radioTheme: RadioThemeData(
+        fillColor: MaterialStateProperty.resolveWith<Color?>((states) {
+          return states.contains(MaterialState.selected)
+              ? _colorScheme.primary
+              : null;
+        }),
+      ),
+      switchTheme: SwitchThemeData(
+        thumbColor: MaterialStateProperty.resolveWith<Color?>((states) {
+          return states.contains(MaterialState.selected)
+              ? _colorScheme.primary
+              : null;
+        }),
+        trackColor: MaterialStateProperty.resolveWith<Color?>((states) {
+          return states.contains(MaterialState.selected)
+              ? _colorScheme.primary
+              : null;
+        }),
+      ));
 
   static const _colorScheme = ColorScheme(
     primary: Color(0xFF6200EE),

--- a/test/theme_test.dart
+++ b/test/theme_test.dart
@@ -12,16 +12,16 @@ void main() {
     final ThemeData themeData = MaterialDemoThemeData.themeData;
 
     expect(
-        themeData.checkboxTheme.fillColor!.resolve({MaterialState.selected}),
-        primaryColor,
+      themeData.checkboxTheme.fillColor!.resolve({MaterialState.selected}),
+      primaryColor,
     );
     expect(
-        themeData.radioTheme.fillColor!.resolve({MaterialState.selected}),
-        primaryColor,
+      themeData.radioTheme.fillColor!.resolve({MaterialState.selected}),
+      primaryColor,
     );
     expect(
-        themeData.switchTheme.thumbColor!.resolve({MaterialState.selected}),
-        primaryColor,
+      themeData.switchTheme.thumbColor!.resolve({MaterialState.selected}),
+      primaryColor,
     );
     expect(
       themeData.switchTheme.trackColor!.resolve({MaterialState.selected}),

--- a/test/theme_test.dart
+++ b/test/theme_test.dart
@@ -7,7 +7,7 @@ import 'package:gallery/themes/material_demo_theme_data.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test('verify code segments are up to date', () async {
+  test('verify former toggleableActiveColor themes are set', () async {
     const Color primaryColor = Color(0xFF6200EE);
     final ThemeData themeData = MaterialDemoThemeData.themeData;
 

--- a/test/theme_test.dart
+++ b/test/theme_test.dart
@@ -1,0 +1,31 @@
+// Copyright 2019 The Flutter team. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'package:flutter/material.dart';
+import 'package:gallery/themes/material_demo_theme_data.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('verify code segments are up to date', () async {
+    const Color primaryColor = Color(0xFF6200EE);
+    final ThemeData themeData = MaterialDemoThemeData.themeData;
+
+    expect(
+        themeData.checkboxTheme.fillColor!.resolve({MaterialState.selected}),
+        primaryColor,
+    );
+    expect(
+        themeData.radioTheme.fillColor!.resolve({MaterialState.selected}),
+        primaryColor,
+    );
+    expect(
+        themeData.switchTheme.thumbColor!.resolve({MaterialState.selected}),
+        primaryColor,
+    );
+    expect(
+      themeData.switchTheme.trackColor!.resolve({MaterialState.selected}),
+      primaryColor,
+    );
+  });
+}


### PR DESCRIPTION
This parameter is being deprecated in https://github.com/flutter/flutter/pull/97972
This migrates off of the old parameter and provides theme data for the other elements that previously used this.

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
