### PR TITLE
Enable scrollbars

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1431,7 +1431,7 @@
   "@demoCupertinoScrollbarTitle": {
     "description": "Title for the cupertino scrollbar demo."
   },
-  "demoCupertinoScrollbarSubtitle": "iOS style scrollbar",
+  "demoCupertinoScrollbarSubtitle": "iOS-style scrollbar",
   "@demoCupertinoScrollbarSubtitle": {
     "description": "Subtitle for the cupertino scrollbar demo."
   },

--- a/lib/l10n/intl_en_US.xml
+++ b/lib/l10n/intl_en_US.xml
@@ -1324,7 +1324,7 @@
   <string
     name="demoCupertinoScrollbarSubtitle"
     description="Subtitle for the cupertino scrollbar demo."
-    >iOS style scrollbar</string>
+    >iOS-style scrollbar</string>
   <string
     name="demoCupertinoScrollbarDescription"
     description="Description for the cupertino scrollbar demo."

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -48,12 +48,6 @@ class GalleryApp extends StatelessWidget {
         builder: (context) {
           final options = GalleryOptions.of(context);
           return MaterialApp(
-            // By default on desktop, scrollbars are applied by the
-            // ScrollBehavior. This overrides that. All vertical scrollables in
-            // the gallery need to be audited before enabling this feature,
-            // see https://github.com/flutter/gallery/issues/523
-            scrollBehavior:
-                const MaterialScrollBehavior().copyWith(scrollbars: false),
             restorationScopeId: 'rootGallery',
             title: 'Flutter Gallery',
             debugShowCheckedModeBanner: false,

--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -532,6 +532,7 @@ class _DesktopCategoryItem extends StatelessWidget {
                 child: ListView.builder(
                   // Makes integration tests possible.
                   key: ValueKey('${category.name}DemoList'),
+                  primary: false,
                   itemBuilder: (context, index) =>
                       CategoryDemoItem(demo: demos[index]),
                   itemCount: demos.length,

--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -908,6 +908,7 @@ class _DesktopCarouselState extends State<_DesktopCarousel> {
               ),
               child: ListView.builder(
                 scrollDirection: Axis.horizontal,
+                primary: false,
                 physics: const _SnappingScrollPhysics(),
                 controller: _controller,
                 itemExtent: itemWidth,


### PR DESCRIPTION
Fixes #523

I can't repro the original issue, but out of caution, I've set `primary: false` on the secondary scrollable on the home screen.