### PR TITLE
Add missing project to .firebaserc

### DIFF
--- a/.firebaserc
+++ b/.firebaserc
@@ -1,4 +1,7 @@
 {
+  "projects": {
+    "gallery": "gallery-flutter-dev"
+  },
   "targets": {
     "gallery-flutter-dev": {
       "hosting": {


### PR DESCRIPTION
To enable GitHub workflow-based web deployments again.