### PR TITLE
Add missing `primary` to home screen list views

### DIFF
--- a/lib/pages/home.dart
+++ b/lib/pages/home.dart
@@ -168,6 +168,7 @@ class HomePage extends StatelessWidget {
         body: ListView(
           // Makes integration tests possible.
           key: const ValueKey('HomeListView'),
+          primary: true,
           padding: const EdgeInsetsDirectional.only(
             top: firstHeaderDesktopTopPadding,
           ),
@@ -383,6 +384,7 @@ class _AnimatedHomePageState extends State<_AnimatedHomePage>
         ListView(
           // Makes integration tests possible.
           key: const ValueKey('HomeListView'),
+          primary: true,
           restorationId: 'home_list_view',
           children: [
             const SizedBox(height: 8),

--- a/test/pages/home_test.dart
+++ b/test/pages/home_test.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:gallery/main.dart';
 
@@ -21,5 +22,15 @@ void main() {
     // are excluded when settings mode is activated.
     expect(find.bySemanticsLabel('Settings'), findsNothing);
     expect(find.bySemanticsLabel('Close settings'), findsOneWidget);
+  });
+
+  testWidgets('Home page list view is the primary list view', (tester) async {
+    await tester.pumpWidget(const GalleryApp());
+    await tester.pumpAndSettle();
+
+    ListView listview =
+        tester.widget(find.byKey(const ValueKey('HomeListView')));
+
+    expect(listview.primary, true);
   });
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,5 +1,0 @@
-// Copyright 2019 The Flutter team. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-
-void main() {}


### PR DESCRIPTION
One for the animated home page, and the other for the non-animated non page. 