### PR TITLE
CardsDemo-HeadingNavigation-SelectedStatus

### DIFF
--- a/lib/demos/material/cards_demo.dart
+++ b/lib/demos/material/cards_demo.dart
@@ -95,7 +95,10 @@ class TravelDestinationItem extends StatelessWidget {
                 // This ensures that the Card's children are clipped correctly.
                 clipBehavior: Clip.antiAlias,
                 shape: shape,
-                child: TravelDestinationContent(destination: destination),
+                child: Semantics(
+                  label: destination.title,
+                  child: TravelDestinationContent(destination: destination),
+                ),
               ),
             ),
           ],
@@ -141,7 +144,10 @@ class TappableTravelDestinationItem extends StatelessWidget {
                       Theme.of(context).colorScheme.onSurface.withOpacity(0.12),
                   // Generally, material cards do not have a highlight overlay.
                   highlightColor: Colors.transparent,
-                  child: TravelDestinationContent(destination: destination),
+                  child: Semantics(
+                    label: destination.title,
+                    child: TravelDestinationContent(destination: destination),
+                  ),
                 ),
               ),
             ),
@@ -172,6 +178,9 @@ class SelectableTravelDestinationItem extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
+    final String selectedStatus = isSelected
+        ? GalleryLocalizations.of(context)!.cardsDemoSelected
+        : GalleryLocalizations.of(context)!.cardsDemoNotSelected;
 
     return SafeArea(
       top: false,
@@ -205,7 +214,15 @@ class SelectableTravelDestinationItem extends StatelessWidget {
                             ? colorScheme.primary.withOpacity(0.08)
                             : Colors.transparent,
                       ),
-                      TravelDestinationContent(destination: destination),
+                      Semantics(
+                        label: '${destination.title} $selectedStatus',
+                        onLongPressHint: isSelected
+                            ? GalleryLocalizations.of(context)!
+                                .cardsDemoDeselect
+                            : GalleryLocalizations.of(context)!.cardsDemoSelect,
+                        child:
+                            TravelDestinationContent(destination: destination),
+                      ),
                       Align(
                         alignment: Alignment.topRight,
                         child: Padding(
@@ -220,6 +237,7 @@ class SelectableTravelDestinationItem extends StatelessWidget {
                       ),
                     ],
                   ),
+                  //),
                 ),
               ),
             ),
@@ -292,9 +310,13 @@ class TravelDestinationContent extends StatelessWidget {
                 child: FittedBox(
                   fit: BoxFit.scaleDown,
                   alignment: Alignment.centerLeft,
-                  child: Text(
-                    destination.title,
-                    style: titleStyle,
+                  child: Semantics(
+                    container: true,
+                    header: true,
+                    child: Text(
+                      destination.title,
+                      style: titleStyle,
+                    ),
                   ),
                 ),
               ),
@@ -302,27 +324,30 @@ class TravelDestinationContent extends StatelessWidget {
           ),
         ),
         // Description and share/explore buttons.
-        Padding(
-          padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
-          child: DefaultTextStyle(
-            softWrap: false,
-            overflow: TextOverflow.ellipsis,
-            style: descriptionStyle,
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                // This array contains the three line description on each card
-                // demo.
-                Padding(
-                  padding: const EdgeInsets.only(bottom: 8),
-                  child: Text(
-                    destination.description,
-                    style: descriptionStyle.copyWith(color: Colors.black54),
+        Semantics(
+          container: true,
+          child: Padding(
+            padding: const EdgeInsets.fromLTRB(16, 16, 16, 0),
+            child: DefaultTextStyle(
+              softWrap: false,
+              overflow: TextOverflow.ellipsis,
+              style: descriptionStyle,
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  // This array contains the three line description on each card
+                  // demo.
+                  Padding(
+                    padding: const EdgeInsets.only(bottom: 8),
+                    child: Text(
+                      destination.description,
+                      style: descriptionStyle.copyWith(color: Colors.black54),
+                    ),
                   ),
-                ),
-                Text(destination.city),
-                Text(destination.location),
-              ],
+                  Text(destination.city),
+                  Text(destination.location),
+                ],
+              ),
             ),
           ),
         ),

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -45,13 +45,9 @@
   "@backToGallery": {
     "description": "Semantic label for back button to exit a study and return to the gallery home page."
   },
-  "cardsDemoTappable": "Tappable",
-  "@cardsDemoTappable": {
-    "description": "The user can tap this button"
-  },
-  "cardsDemoSelectable": "Selectable (long press)",
-  "@cardsDemoSelectable": {
-    "description": "If the user taps and hold this card. The card will toggled between on and off."
+  "cardsDemoDeselect": "Deselect",
+  "@cardsDemoUnselect": {
+    "description": "Deselect a (selectable) card"
   },
   "cardsDemoExplore": "Explore",
   "@cardsDemoExplore": {
@@ -66,6 +62,22 @@
       }
     }
   },
+  "cardsDemoNotSelected": "Not selected",
+  "@cardsDemoNotSelected": {
+    "description": "Indicates the status of a (selectable) card being not selected"
+  },
+  "cardsDemoSelect": "Select",
+  "@cardsDemoSelect": {
+    "description": "Select a (selectable) card"
+  },
+  "cardsDemoSelectable": "Selectable (long press)",
+  "@cardsDemoSelectable": {
+    "description": "If the user taps and hold this card. The card will toggled between on and off."
+  },
+  "cardsDemoSelected": "Selected",
+  "@cardsDemoSelected": {
+    "description": "Indicates selected status of a (selectable) card"
+  },
   "cardsDemoShareSemantics": "Share {destinationName}",
   "@cardsDemoShareSemantics": {
     "description": "Semantics label for Share. Label tells user to share the destinationName to the user. Example Share Tamil",
@@ -74,6 +86,10 @@
         "example": "Tamil"
       }
     }
+  },
+  "cardsDemoTappable": "Tappable",
+  "@cardsDemoTappable": {
+    "description": "The user can tap this button"
   },
   "cardsDemoTravelDestinationTitle1": "Top 10 Cities to Visit in Tamil Nadu",
   "@cardsDemoTravelDestinationTitle1": {


### PR DESCRIPTION
This PR modified CardsDemo so that the title of the card is reachable by TalkBack Heading Navigation, and the semantics labels indicate selected/not selected status for the selectable card.

Bugs fixed:
b/238636981
b/238635836

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
