### PR TITLE
Remove unnecessary `!` operator.

### DIFF
--- a/test_benchmarks/benchmarks/scroll.dart
+++ b/test_benchmarks/benchmarks/scroll.dart
@@ -85,7 +85,7 @@ Future<void> scrollUntilVisible({
   final elementRect = _absoluteRect(elementRenderObject);
 
   final scrollable = Scrollable.of(element);
-  final viewport = RenderAbstractViewport.of(elementRenderObject)!;
+  final viewport = RenderAbstractViewport.of(elementRenderObject);
 
   final visibleWindow = _absoluteRect(viewport).intersect(_windowRect(element));
 
@@ -95,13 +95,13 @@ Future<void> scrollUntilVisible({
       _hasSufficientFreeRoom(
         large: visibleWindow,
         small: elementRect,
-        axisDirection: scrollable!.axisDirection,
+        axisDirection: scrollable.axisDirection,
       )) {
     return;
   }
 
   late double pixelsToBeMoved;
-  switch (scrollable!.axisDirection) {
+  switch (scrollable.axisDirection) {
     case AxisDirection.down:
       pixelsToBeMoved = elementRect.top - visibleWindow.top;
       break;


### PR DESCRIPTION
These cause failure on the SDK [build](https://dart-review.googlesource.com/c/sdk/+/266400?tab=checks), with a log of:

```
warning - test_benchmarks/benchmarks/scroll.dart:88:66 - The '!' will have no effect because the receiver can't be null. Try removing the '!' operator. - unnecessary_non_null_assertion
warning - test_benchmarks/benchmarks/scroll.dart:98:34 - The '!' will have no effect because the receiver can't be null. Try removing the '!' operator. - unnecessary_non_null_assertion
warning - test_benchmarks/benchmarks/scroll.dart:104:21 - The '!' will have no effect because the receiver can't be null. Try removing the '!' operator. - unnecessary_non_null_assertion
```
## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [ ] I listed at least one issue that this PR fixes in the description above.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making, or this PR is [test-exempt].
- [ ] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
