### PR TITLE
Fixed misleading announcement for all demos

### DIFF
--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -2230,6 +2230,10 @@
   "@chipBiking": {
     "description": "A chip component to that indicates a biking selection."
   },
+  "demo": "Demo",
+  "@demo": {
+    "description": "Used in the title of the demos."
+  },
   "dialogDiscardTitle": "Discard draft?",
   "@dialogDiscardTitle": {
     "description": "Alert dialog message to discard draft."

--- a/lib/l10n/intl_en_US.xml
+++ b/lib/l10n/intl_en_US.xml
@@ -2098,6 +2098,10 @@
     description="A chip component to that indicates a biking selection."
     >Biking</string>
   <string
+    name="demo"
+    description="Used in the title of the demos."
+    >Demo</string>
+  <string
     name="dialogDiscardTitle"
     description="Alert dialog message to discard draft."
     >Discard draft?</string>

--- a/lib/pages/demo.dart
+++ b/lib/pages/demo.dart
@@ -428,17 +428,18 @@ class _GalleryDemoPageState extends State<GalleryDemoPage>
       final isDemoNormal = currentDemoState == _DemoState.normal;
       // Add a tap gesture to collapse the currently opened section.
       demoContent = Semantics(
-        label: MaterialLocalizations.of(context).modalBarrierDismissLabel,
+        label:
+            '${GalleryLocalizations.of(context)!.demo}, ${widget.demo.title}',
         child: MouseRegion(
           cursor: isDemoNormal ? MouseCursor.defer : SystemMouseCursors.click,
           child: GestureDetector(
-            onTap: () {
-              if (!isDemoNormal) {
-                setStateAndUpdate(() {
-                  _demoStateIndex.value = _DemoState.normal.index;
-                });
-              }
-            },
+            onTap: isDemoNormal
+                ? null
+                : () {
+                    setStateAndUpdate(() {
+                      _demoStateIndex.value = _DemoState.normal.index;
+                    });
+                  },
             child: Semantics(
               excludeSemantics: !isDemoNormal,
               child: demoContent,


### PR DESCRIPTION
This PR fixes the misleading announcement for all gallery demos, which was previously "Dismiss, double tap to activate" so that:
When focusing on the entire demo page, the title of the demo is announced properly;
No announcement of "Double tap to activate" if there is no action available.

Issue fixed: b/256614760

## Pre-launch Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [x] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [x] I signed the [CLA].
- [x] I listed at least one issue that this PR fixes in the description above.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making, or this PR is [test-exempt].
- [x] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
