### PR TITLE
Scroll 75% of x, y on each list scroll increment

### DIFF
--- a/test_driver/transitions_perf_test.dart
+++ b/test_driver/transitions_perf_test.dart
@@ -166,11 +166,27 @@ Future<void> runDemos(
     demoItem = find.byValueKey(demo);
 
     stdout.writeln('scrolling to demo');
+
+    // demoList below may be either the horizontally-scrolling Studies carousel
+    // or vertically scrolling Material/Cupertino/Other demo lists.
+    //
+    // The Studies carousel has scroll physics that snap items to the starting
+    // edge of the widget. TestDriver.scrollUntilVisible scrolls in increments
+    // along the x and y axes; if the distance is too small, the list snaps
+    // back to its previous position, if it's too large, it may scroll too far.
+    // To resolve this, we scroll 75% of the list width/height dimensions on
+    // each increment.
+    final DriverOffset topLeft =
+        await driver.getTopLeft(demoList, timeout: const Duration(seconds: 10));
+    final DriverOffset bottomRight = await driver.getBottomRight(demoList,
+        timeout: const Duration(seconds: 10));
+    final double listWidth = bottomRight.dx - topLeft.dx;
+    final double listHeight = bottomRight.dy - topLeft.dy;
     await driver.scrollUntilVisible(
       demoList,
       demoItem,
-      dxScroll: -800,
-      dyScroll: -50,
+      dxScroll: -listWidth * 0.75,
+      dyScroll: -listHeight * 0.75,
       alignment: 0.5,
       timeout: const Duration(seconds: 10),
     );


### PR DESCRIPTION
The gallery driver test includes logic to scroll through various lists of demos in order to transition to each one. These lists include the horizontally-scrolling studies list at the top of the gallery home page, as well as the vertically-scrolling Material, Cupertino, and Other demo lists on the same page.

TestDriver.scrollUntilVisible scrolls a parent list widget in increments of dx and/or dy until the specified list item widget is visible. The Studies carousel list at the top of the gallery home screen has scroll physics that snap items to the starting edge of the widget. If the dx scroll distance is too small, the Studies list doesn't scroll far enough and snaps back to its original position. Conversely, if it scrolls too far, it may scroll one widget too far and snap the next widget into place. Instead, we now scroll 75% of the carousel width (empirically determined) as an attempt at a value in the Goldilocks Zone.

Related: https://github.com/flutter/gallery/pull/792 Related: https://github.com/flutter/flutter/issues/111131

Issue: https://github.com/flutter/flutter/issues/114025


## Pre-launch Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] I read the [Tree Hygiene] wiki page, which explains my responsibilities.
- [X] I read the [Flutter Style Guide] _recently_, and have followed its advice.
- [X] I signed the [CLA].
- [X] I listed at least one issue that this PR fixes in the description above.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] I added new tests to check the change I am making, or this PR is [test-exempt].
- [X] All existing and new tests are passing.

If you need help, consider asking for advice on the #hackers-new channel on [Discord].

<!-- Links -->
[Contributor Guide]: https://github.com/flutter/flutter/wiki/Tree-hygiene#overview
[Tree Hygiene]: https://github.com/flutter/flutter/wiki/Tree-hygiene
[test-exempt]: https://github.com/flutter/flutter/wiki/Tree-hygiene#tests
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[CLA]: https://cla.developers.google.com/
[flutter/tests]: https://github.com/flutter/tests
[breaking change policy]: https://github.com/flutter/flutter/wiki/Tree-hygiene#handling-breaking-changes
[Discord]: https://github.com/flutter/flutter/wiki/Chat
