### PR TITLE
Remove the no-longer-supported "strong-mode" analysis options category

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,10 +1,5 @@
 include: package:flutter_lints/flutter.yaml
 
-analyzer:
-  strong-mode:
-    implicit-casts: false
-    implicit-dynamic: false
-
 linter:
   # In addition to the flutter_lints
   rules:


### PR DESCRIPTION
After [0] landed this makes flutter-analyze builder red due to unsupported entries in the gallery's analysis_options.yaml file.

[0] https://dart-review.googlesource.com/c/sdk/+/274921