### PR TITLE
Suppress l10n warnings

### DIFF
--- a/l10n.yaml
+++ b/l10n.yaml
@@ -4,3 +4,4 @@ output-class: GalleryLocalizations
 preferred-supported-locales:
   - en
 use-deferred-loading: true
+suppress-warnings: true


### PR DESCRIPTION
## Description
This change suppresses l10n warnings. Currently the only warning implemented in the `gen-l10n` tool is to warn users if they have a repeated plural case, since this renders one of the plural case useless. However, it seems that Google distinguishes between the `=1` and `one` case, but these are interpreted to be the same thing in ICU's messageFormat syntax.

## Issues
Fixes #893.
