### PR TITLE
Fixed small typos on windows deployment yaml.

### DIFF
--- a/.github/workflows/release_deploy_windows.yml
+++ b/.github/workflows/release_deploy_windows.yml
@@ -15,13 +15,13 @@ jobs:
       
       # Instructions on obtaining these secrets can be found at https://github.com/marketplace/actions/windows-store-publish#obtaining-your-credentials
       - name: Configure MS CLI
-        run: msstore reconfigure --tenantId ${{ secrets.AZURE_AD_TENANT_ID }} --clientId ${{ secrets.AZURE_AD_ClIENT_ID }} --clientSecret ${{ secrets.AZURE_AD_CLIENT_SECRET }} --sellerId ${{ secrets.SELLER_ID }}
+        run: msstore reconfigure --tenantId ${{ secrets.AZURE_AD_TENANT_ID }} --clientId ${{ secrets.AZURE_AD_CLIENT_ID }} --clientSecret ${{ secrets.AZURE_AD_CLIENT_SECRET }} --sellerId ${{ secrets.SELLER_ID }}
 
       - name: Install dependencies
         run: dart pub get
       
       - name: Create MSIX package
-        run: msstore package .
+        run: msstore package
       
       - name: Publish MSIX to the Microsoft Store
         run: msstore publish -v

--- a/.github/workflows/release_deploy_windows.yml
+++ b/.github/workflows/release_deploy_windows.yml
@@ -18,7 +18,7 @@ jobs:
         run: msstore reconfigure --tenantId ${{ secrets.AZURE_AD_TENANT_ID }} --clientId ${{ secrets.AZURE_AD_CLIENT_ID }} --clientSecret ${{ secrets.AZURE_AD_CLIENT_SECRET }} --sellerId ${{ secrets.SELLER_ID }}
 
       - name: Install dependencies
-        run: dart pub get
+        run: flutter pub get
       
       - name: Create MSIX package
         run: msstore package


### PR DESCRIPTION
## Description

Very small typo fix. Secret name was mistyped, and the dot (".") is not required, as the Store CLI uses the current directory by default.