### PR TITLE
Update permission for code scanning alert

### DIFF
--- a/.github/workflows/release_deploy_windows.yml
+++ b/.github/workflows/release_deploy_windows.yml
@@ -2,6 +2,9 @@ name: Publish MSIX to Microsoft Store
 
 on: workflow_dispatch
 
+# Declare default permissions as read only.
+permissions: read-all
+
 jobs:
   build:
     runs-on: windows-latest


### PR DESCRIPTION
Set permission for windows store release to read-only.

Addresses https://github.com/flutter/gallery/issues/938

---

>**Note**: Please find the development and releasing instructions at https://github.com/flutter/gallery#development
