### PR TITLE
[Windows] Ensure the app window is shown

### DIFF
--- a/windows/runner/flutter_window.cpp
+++ b/windows/runner/flutter_window.cpp
@@ -31,6 +31,11 @@ bool FlutterWindow::OnCreate() {
     this->Show();
   });
 
+  // Flutter can complete the first frame before the "show window" callback is
+  // registered. The following call ensures a frame is pending to ensure the
+  // window is shown. It is a no-op if the first frame hasn't completed yet.
+  flutter_controller_->ForceRedraw();
+
   return true;
 }
 


### PR DESCRIPTION
Migrate the Gallery app to ensure the window is shown.

Part of https://github.com/flutter/flutter/issues/127695
Used by https://github.com/flutter/website/pull/9269