### PR TITLE
Update to build with Dart 3 language version

### DIFF
--- a/lib/codeviewer/code_segments.dart
+++ b/lib/codeviewer/code_segments.dart
@@ -48156,7 +48156,7 @@ class CodeSegments {
       TextSpan(style: codeStyle.baseStyle, text: ' '),
       TextSpan(style: codeStyle.classStyle, text: '_BoardIterator'),
       TextSpan(style: codeStyle.baseStyle, text: ' '),
-      TextSpan(style: codeStyle.keywordStyle, text: 'extends'),
+      TextSpan(style: codeStyle.keywordStyle, text: 'implements'),
       TextSpan(style: codeStyle.baseStyle, text: ' '),
       TextSpan(style: codeStyle.classStyle, text: 'Iterator'),
       TextSpan(style: codeStyle.punctuationStyle, text: '<'),

--- a/lib/demos/reference/transformations_demo_board.dart
+++ b/lib/demos/reference/transformations_demo_board.dart
@@ -217,7 +217,7 @@ class Board extends Object with IterableMixin<BoardPoint?> {
   }
 }
 
-class _BoardIterator extends Iterator<BoardPoint?> {
+class _BoardIterator implements Iterator<BoardPoint?> {
   _BoardIterator(this.boardPoints);
 
   final List<BoardPoint> boardPoints;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -5,7 +5,7 @@ version: 2.10.2+021002 # See README.md for details on versioning.
 
 environment:
   flutter: ^3.13.0
-  sdk: ">=2.17.0"
+  sdk: ^3.1.0
 
 dependencies:
   flutter:


### PR DESCRIPTION
`Iterator` is now an `abstract interface class`, so we can no longer extend it.