### PR TITLE
Fix mounted checks

### DIFF
--- a/lib/pages/demo.dart
+++ b/lib/pages/demo.dart
@@ -167,7 +167,7 @@ class _GalleryDemoPageState extends State<GalleryDemoPage>
 
     if (await canLaunchUrlString(url)) {
       await launchUrlString(url);
-    } else if (mounted) {
+    } else if (context.mounted) {
       await showDialog<void>(
         context: context,
         builder: (context) {


### PR DESCRIPTION
Fixes in preparation for https://dart-review.googlesource.com/c/sdk/+/330561.

The change referenced above tightens the `use_build_context_synchronously` lint to ensure that `mounted` is checked on the appropriate `BuildContext` or `State`. This change fixes up the gallery in preparation of this new enforcement.