### PR TITLE
fixing dateTime navigator null exception on canle dialog

### DIFF
--- a/lib/demos/cupertino/cupertino_alert_demo.dart
+++ b/lib/demos/cupertino/cupertino_alert_demo.dart
@@ -62,10 +62,12 @@ class _CupertinoAlertDemoState extends State<CupertinoAlertDemo>
     );
   }
 
-  void _setSelectedValue(String value) {
-    setState(() {
-      lastSelectedValue.value = value;
-    });
+  void _setSelectedValue(String? value) {
+    if(value!=null) {
+      setState(() {
+        lastSelectedValue.value = value;
+      });
+    }
   }
 
   @override

--- a/lib/demos/material/dialog_demo.dart
+++ b/lib/demos/material/dialog_demo.dart
@@ -44,16 +44,19 @@ class _DialogDemoState extends State<DialogDemo> with RestorationMixin {
   }
 
   // Displays the popped String value in a SnackBar.
-  void _showInSnackBar(String value) {
+  void _showInSnackBar(String? value) {
     // The value passed to Navigator.pop() or null.
     ScaffoldMessenger.of(context).hideCurrentSnackBar();
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(
-        content: Text(
-          GalleryLocalizations.of(context)!.dialogSelectedOption(value),
+    if(value != null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+
+        SnackBar(
+          content: Text(
+            GalleryLocalizations.of(context)!.dialogSelectedOption(value!),
+          ),
         ),
-      ),
-    );
+      );
+    }
   }
 
   @override

--- a/lib/demos/material/picker_demo.dart
+++ b/lib/demos/material/picker_demo.dart
@@ -31,27 +31,33 @@ class _PickerDemoState extends State<PickerDemo> with RestorationMixin {
       _restorableDateRangePickerRouteFuture;
   late RestorableRouteFuture<TimeOfDay> _restorableTimePickerRouteFuture;
 
-  void _selectDate(DateTime selectedDate) {
-    if (selectedDate != _fromDate.value) {
-      setState(() {
-        _fromDate.value = selectedDate;
-      });
+  void _selectDate(DateTime? selectedDate) {
+    if(selectedDate != null) {
+      if (selectedDate != _fromDate.value) {
+        setState(() {
+          _fromDate.value = selectedDate;
+        });
+      }
     }
   }
 
-  void _selectDateRange(DateTimeRange newSelectedDate) {
+  void _selectDateRange(DateTimeRange? newSelectedDate) {
+   if(newSelectedDate!=null){
+     setState(() {
+       _startDate.value = newSelectedDate.start;
+       _endDate.value = newSelectedDate.end;
+     });
+   }
+  }
+
+  void _selectTime(TimeOfDay? selectedTime) {
+if(selectedTime!=null){
+  if (selectedTime != _fromTime.value) {
     setState(() {
-      _startDate.value = newSelectedDate.start;
-      _endDate.value = newSelectedDate.end;
+      _fromTime.value = selectedTime;
     });
   }
-
-  void _selectTime(TimeOfDay selectedTime) {
-    if (selectedTime != _fromTime.value) {
-      setState(() {
-        _fromTime.value = selectedTime;
-      });
-    }
+}
   }
 
   static Route<DateTime> _datePickerRoute(


### PR DESCRIPTION
This PR changes the navigator on Complete method to make it receives a nullable value so that when the navigator is canceled and no date is selected no exception gets thrown as 'type 'Null' is not a subtype of type 'DateTime' in type cast'

Fixes #1041

---

>**Note**: Please find the development and releasing instructions at https://github.com/flutter/gallery#development
